### PR TITLE
Scrum 15 cb 302 organization detail page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1032,7 +1032,13 @@ function App() {
               <div className="space-y-3">
                 <div className="p-2 rounded bg-slate-100">Home</div>
                 <div className="p-2 rounded bg-slate-100">Events</div>
-                <div className="p-2 rounded bg-slate-100">Clubs</div>
+                <button
+                  type="button"
+                  onClick={() => navigate("/organizations")}
+                  className="w-full rounded bg-slate-100 p-2 text-left transition hover:bg-blue-50 hover:text-blue-700"
+                >
+                  Organizations
+                </button>
                 <div className="p-2 rounded bg-slate-100">Calendar</div>
                 <div className="p-2 rounded bg-slate-100">Profile</div>
                 <div className="p-2 rounded bg-slate-100">Settings</div>

--- a/client/src/api/organizations.js
+++ b/client/src/api/organizations.js
@@ -1,5 +1,6 @@
 import { supabase } from "../supabaseClient";
 import { normalizePost } from "../lib/postUtils";
+import { apiRequest } from "./config";
 
 const ORGANIZATION_FIELDS = [
   "id",
@@ -19,6 +20,68 @@ function sortOrganizations(organizations) {
   });
 }
 
+function countComments(comments) {
+  return Array.isArray(comments) ? comments.length : 0;
+}
+
+function countLikes(likes) {
+  const value = Number(likes ?? 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function buildOrganizationSummaries({ organizations, followers, posts, userId }) {
+  return sortOrganizations(
+    organizations.map((organization) => {
+      const organizationFollowers = followers.filter(
+        (follower) => follower.organization_id === organization.id
+      );
+      const organizationPosts = posts.filter(
+        (post) => post.user_id === organization.profile_id
+      );
+
+      return {
+        ...organization,
+        followers_count: organizationFollowers.length,
+        posts_count: organizationPosts.length,
+        likes_count: organizationPosts.reduce(
+          (total, post) => total + countLikes(post.likes),
+          0
+        ),
+        comments_count: organizationPosts.reduce(
+          (total, post) => total + countComments(post.comments),
+          0
+        ),
+        is_following: Boolean(
+          userId &&
+            organizationFollowers.some((follower) => follower.user_id === userId)
+        ),
+      };
+    })
+  );
+}
+
+async function fetchOrganizationSummariesFromSupabase(userId) {
+  const [organizationsResult, followersResult, postsResult] = await Promise.all([
+    supabase.from("organizations").select(ORGANIZATION_FIELDS),
+    supabase.from("organization_followers").select("user_id, organization_id"),
+    supabase.from("posts").select("id, user_id, likes, comments"),
+  ]);
+
+  const firstError =
+    organizationsResult.error || followersResult.error || postsResult.error;
+
+  if (firstError) {
+    throw new Error(firstError.message);
+  }
+
+  return buildOrganizationSummaries({
+    organizations: organizationsResult.data ?? [],
+    followers: followersResult.data ?? [],
+    posts: postsResult.data ?? [],
+    userId,
+  });
+}
+
 export async function fetchOrganizations() {
   const { data, error } = await supabase
     .from("organizations")
@@ -29,6 +92,20 @@ export async function fetchOrganizations() {
   }
 
   return sortOrganizations(data ?? []);
+}
+
+export async function fetchOrganizationSummaries(userId) {
+  const query = userId ? `?user_id=${encodeURIComponent(userId)}` : "";
+  try {
+    const payload = await apiRequest(`/api/organizations${query}`);
+    return Array.isArray(payload) ? payload : payload.organizations ?? [];
+  } catch (error) {
+    if (error instanceof TypeError || /failed to fetch/i.test(error.message)) {
+      return fetchOrganizationSummariesFromSupabase(userId);
+    }
+
+    throw error;
+  }
 }
 
 export async function fetchOrganizationById(orgId) {

--- a/client/src/components/OrganizationCard.jsx
+++ b/client/src/components/OrganizationCard.jsx
@@ -1,0 +1,87 @@
+import AvatarBadge from "./AvatarBadge";
+import OrganizationStat from "./OrganizationStat";
+
+export default function OrganizationCard({
+  organization,
+  onOpen,
+  onFollow,
+  followLoading = false,
+}) {
+  const name = organization.name || organization.username || "Organization";
+  const canFollow = !organization.is_following && !organization.is_own_organization;
+
+  const handleFollowClick = (event) => {
+    event.stopPropagation();
+    onFollow?.(organization);
+  };
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(organization)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen(organization);
+        }
+      }}
+      className="flex h-full cursor-pointer flex-col rounded-md border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-200"
+    >
+      <div className="flex items-start gap-4">
+        <AvatarBadge src={organization.logo_url} label={name} size="lg" />
+
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-lg font-semibold text-slate-900">
+            {name}
+          </h2>
+          <p className="mt-1 truncate text-sm text-slate-500">
+            @{organization.username || "organization"}
+          </p>
+        </div>
+
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${
+            organization.is_following
+              ? "bg-emerald-50 text-emerald-700"
+              : "bg-slate-100 text-slate-600"
+          }`}
+        >
+          {organization.is_following ? "Following" : "Not following"}
+        </span>
+      </div>
+
+      <p className="mt-4 min-h-[4.5rem] overflow-hidden text-sm leading-6 text-slate-600">
+        {organization.description || "This organization has not added a description yet."}
+      </p>
+
+      <div className="mt-5 grid grid-cols-2 gap-3">
+        <OrganizationStat label="Followers" value={organization.followers_count} />
+        <OrganizationStat label="Posts" value={organization.posts_count} />
+        <OrganizationStat label="Likes" value={organization.likes_count} />
+        <OrganizationStat label="Comments" value={organization.comments_count} />
+      </div>
+
+      <div className="mt-5 flex justify-end">
+        {organization.is_own_organization ? (
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-600">
+            Your organization
+          </span>
+        ) : canFollow ? (
+          <button
+            type="button"
+            onClick={handleFollowClick}
+            disabled={followLoading}
+            className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {followLoading ? "Following..." : "Follow"}
+          </button>
+        ) : (
+          <span className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-white">
+            Following
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/client/src/components/OrganizationCard.jsx
+++ b/client/src/components/OrganizationCard.jsx
@@ -40,15 +40,6 @@ export default function OrganizationCard({
           </p>
         </div>
 
-        <span
-          className={`rounded-full px-3 py-1 text-xs font-semibold ${
-            organization.is_following
-              ? "bg-emerald-50 text-emerald-700"
-              : "bg-slate-100 text-slate-600"
-          }`}
-        >
-          {organization.is_following ? "Following" : "Not following"}
-        </span>
       </div>
 
       <p className="mt-4 min-h-[4.5rem] overflow-hidden text-sm leading-6 text-slate-600">
@@ -77,9 +68,14 @@ export default function OrganizationCard({
             {followLoading ? "Following..." : "Follow"}
           </button>
         ) : (
-          <span className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-white">
-            Following
-          </span>
+          <button
+            type="button"
+            onClick={handleFollowClick}
+            disabled={followLoading}
+            className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-900 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {followLoading ? "Updating..." : "Following"}
+          </button>
         )}
       </div>
     </article>

--- a/client/src/components/OrganizationStat.jsx
+++ b/client/src/components/OrganizationStat.jsx
@@ -1,0 +1,10 @@
+export default function OrganizationStat({ label, value }) {
+  return (
+    <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+      <div className="text-lg font-semibold leading-tight text-slate-900">
+        {Number(value ?? 0).toLocaleString()}
+      </div>
+      <div className="mt-1 text-xs font-medium text-slate-500">{label}</div>
+    </div>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -11,6 +11,7 @@ import "./index.css";
 import App from "./App.jsx";
 import AuthPage from "./pages/AuthPage";
 import OrganizationDetailsPage from "./pages/OrganizationDetailsPage";
+import OrganizationsPage from "./pages/OrganizationsPage";
 import { supabase } from "./supabaseClient";
 
 function RequireAuth({ children }) {
@@ -67,6 +68,14 @@ createRoot(document.getElementById("root")).render(
           element={
             <RequireAuth>
               <App />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/organizations"
+          element={
+            <RequireAuth>
+              <OrganizationsPage />
             </RequireAuth>
           }
         />

--- a/client/src/pages/OrganizationsPage.jsx
+++ b/client/src/pages/OrganizationsPage.jsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import OrganizationCard from "../components/OrganizationCard";
+import {
+  fetchOrganizationSummaries,
+  followOrganization,
+} from "../api/organizations";
+import { supabase } from "../supabaseClient";
+
+export default function OrganizationsPage() {
+  const navigate = useNavigate();
+  const [organizations, setOrganizations] = useState([]);
+  const [sessionUserId, setSessionUserId] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [followLoadingId, setFollowLoadingId] = useState(null);
+  const [actionError, setActionError] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadOrganizations() {
+      setLoading(true);
+      setError("");
+      setActionError("");
+
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        const currentUserId = session?.user?.id ?? null;
+        const summaries = await fetchOrganizationSummaries(currentUserId);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setSessionUserId(currentUserId);
+        setOrganizations(
+          summaries.map((organization) => ({
+            ...organization,
+            is_own_organization:
+              Boolean(currentUserId) && organization.profile_id === currentUserId,
+          }))
+        );
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError.message || "Unable to load organizations.");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadOrganizations();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const totals = useMemo(
+    () =>
+      organizations.reduce(
+        (summary, organization) => ({
+          organizations: summary.organizations + 1,
+          posts: summary.posts + Number(organization.posts_count ?? 0),
+          followers: summary.followers + Number(organization.followers_count ?? 0),
+        }),
+        { organizations: 0, posts: 0, followers: 0 }
+      ),
+    [organizations]
+  );
+
+  const handleOpenOrganization = (organization) => {
+    navigate(`/organizations/${organization.id}`);
+  };
+
+  const handleToggleFollow = async (organization) => {
+    if (!sessionUserId || organization.is_own_organization) {
+      return;
+    }
+
+    if (organization.is_following) {
+      return;
+    }
+
+    const nextFollowing = true;
+    setFollowLoadingId(organization.id);
+    setActionError("");
+    setOrganizations((currentOrganizations) =>
+      currentOrganizations.map((item) =>
+        item.id === organization.id
+          ? {
+              ...item,
+              is_following: nextFollowing,
+              followers_count: Math.max(
+                0,
+                Number(item.followers_count ?? 0) + (nextFollowing ? 1 : -1)
+              ),
+            }
+          : item
+      )
+    );
+
+    try {
+      await followOrganization(sessionUserId, organization.id);
+    } catch (followError) {
+      setOrganizations((currentOrganizations) =>
+        currentOrganizations.map((item) =>
+          item.id === organization.id
+            ? {
+                ...item,
+                is_following: !nextFollowing,
+                followers_count: Math.max(
+                  0,
+                  Number(item.followers_count ?? 0) + (nextFollowing ? -1 : 1)
+                ),
+              }
+            : item
+        )
+      );
+      setActionError(followError.message || "Unable to update follow status.");
+    } finally {
+      setFollowLoadingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-sky-200 via-blue-100 to-slate-200 px-4 py-8">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => navigate("/")}
+            className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            Back to Dashboard
+          </button>
+
+          <div className="flex flex-wrap gap-2 text-sm text-slate-700">
+            <span className="rounded-full bg-white/85 px-3 py-1 shadow-sm">
+              {totals.organizations} organizations
+            </span>
+            <span className="rounded-full bg-white/85 px-3 py-1 shadow-sm">
+              {totals.posts} posts
+            </span>
+            <span className="rounded-full bg-white/85 px-3 py-1 shadow-sm">
+              {totals.followers} followers
+            </span>
+          </div>
+        </div>
+
+        <section className="rounded-md border border-white/70 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.14)] backdrop-blur">
+          <div className="mb-6">
+            <h1 className="text-3xl font-semibold text-slate-900">
+              Organizations
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Browse campus organizations, see their activity, and follow the
+              groups you want in your feed.
+            </p>
+          </div>
+
+          {actionError && (
+            <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              {actionError}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="rounded-md border border-slate-200 bg-white p-8 text-center text-slate-600">
+              Loading organizations...
+            </div>
+          ) : error ? (
+            <div className="rounded-md border border-red-200 bg-red-50 p-8 text-center text-red-700">
+              {error}
+            </div>
+          ) : organizations.length === 0 ? (
+            <div className="rounded-md border border-dashed border-slate-300 bg-white/85 p-8 text-center text-slate-600">
+              No organizations are available yet.
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {organizations.map((organization) => (
+                <OrganizationCard
+                  key={organization.id}
+                  organization={organization}
+                  onOpen={handleOpenOrganization}
+                  onFollow={handleToggleFollow}
+                  followLoading={followLoadingId === organization.id}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/OrganizationsPage.jsx
+++ b/client/src/pages/OrganizationsPage.jsx
@@ -8,9 +8,70 @@ import {
 } from "../api/organizations";
 import { supabase } from "../supabaseClient";
 
+const ORGANIZATION_FILTERS = [
+  { value: "relevant", label: "Most Relevant" },
+  { value: "featured", label: "Most Featured" },
+  { value: "liked", label: "Most Liked" },
+];
+
+function metricValue(organization, key) {
+  const value = Number(organization[key] ?? 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function organizationName(organization) {
+  return (organization.name || organization.username || "").toLowerCase();
+}
+
+function relevanceScore(organization) {
+  return (
+    (organization.is_following ? 1000 : 0) +
+    metricValue(organization, "posts_count") * 8 +
+    metricValue(organization, "followers_count") * 4 +
+    metricValue(organization, "likes_count") * 2 +
+    metricValue(organization, "comments_count") * 3
+  );
+}
+
+function featuredScore(organization) {
+  return (
+    metricValue(organization, "followers_count") * 6 +
+    metricValue(organization, "posts_count") * 10 +
+    metricValue(organization, "comments_count") * 2
+  );
+}
+
+function compareByScore(left, right, scoreFor) {
+  const scoreDelta = scoreFor(right) - scoreFor(left);
+  if (scoreDelta !== 0) {
+    return scoreDelta;
+  }
+
+  return organizationName(left).localeCompare(organizationName(right));
+}
+
+function sortOrganizationsByFilter(organizations, filter) {
+  const sorted = [...organizations];
+
+  if (filter === "featured") {
+    return sorted.sort((left, right) => compareByScore(left, right, featuredScore));
+  }
+
+  if (filter === "liked") {
+    return sorted.sort((left, right) =>
+      compareByScore(right, left, (organization) =>
+        -metricValue(organization, "likes_count")
+      )
+    );
+  }
+
+  return sorted.sort((left, right) => compareByScore(left, right, relevanceScore));
+}
+
 export default function OrganizationsPage() {
   const navigate = useNavigate();
   const [organizations, setOrganizations] = useState([]);
+  const [activeFilter, setActiveFilter] = useState("relevant");
   const [sessionUserId, setSessionUserId] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -73,6 +134,11 @@ export default function OrganizationsPage() {
         { organizations: 0, posts: 0, followers: 0 }
       ),
     [organizations]
+  );
+
+  const visibleOrganizations = useMemo(
+    () => sortOrganizationsByFilter(organizations, activeFilter),
+    [organizations, activeFilter]
   );
 
   const handleOpenOrganization = (organization) => {
@@ -165,6 +231,28 @@ export default function OrganizationsPage() {
             </p>
           </div>
 
+          <div className="mb-5 flex flex-wrap items-center gap-2">
+            {ORGANIZATION_FILTERS.map((filter) => {
+              const isActive = activeFilter === filter.value;
+
+              return (
+                <button
+                  key={filter.value}
+                  type="button"
+                  onClick={() => setActiveFilter(filter.value)}
+                  aria-pressed={isActive}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    isActive
+                      ? "bg-slate-900 text-white shadow-sm"
+                      : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              );
+            })}
+          </div>
+
           {actionError && (
             <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
               {actionError}
@@ -179,13 +267,13 @@ export default function OrganizationsPage() {
             <div className="rounded-md border border-red-200 bg-red-50 p-8 text-center text-red-700">
               {error}
             </div>
-          ) : organizations.length === 0 ? (
+          ) : visibleOrganizations.length === 0 ? (
             <div className="rounded-md border border-dashed border-slate-300 bg-white/85 p-8 text-center text-slate-600">
               No organizations are available yet.
             </div>
           ) : (
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {organizations.map((organization) => (
+              {visibleOrganizations.map((organization) => (
                 <OrganizationCard
                   key={organization.id}
                   organization={organization}

--- a/client/src/pages/OrganizationsPage.jsx
+++ b/client/src/pages/OrganizationsPage.jsx
@@ -4,6 +4,7 @@ import OrganizationCard from "../components/OrganizationCard";
 import {
   fetchOrganizationSummaries,
   followOrganization,
+  unfollowOrganization,
 } from "../api/organizations";
 import { supabase } from "../supabaseClient";
 
@@ -83,11 +84,7 @@ export default function OrganizationsPage() {
       return;
     }
 
-    if (organization.is_following) {
-      return;
-    }
-
-    const nextFollowing = true;
+    const nextFollowing = !organization.is_following;
     setFollowLoadingId(organization.id);
     setActionError("");
     setOrganizations((currentOrganizations) =>
@@ -106,7 +103,11 @@ export default function OrganizationsPage() {
     );
 
     try {
-      await followOrganization(sessionUserId, organization.id);
+      if (nextFollowing) {
+        await followOrganization(sessionUserId, organization.id);
+      } else {
+        await unfollowOrganization(sessionUserId, organization.id);
+      }
     } catch (followError) {
       setOrganizations((currentOrganizations) =>
         currentOrganizations.map((item) =>

--- a/client/tests/organizations-page.test.jsx
+++ b/client/tests/organizations-page.test.jsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OrganizationsPage from "../src/pages/OrganizationsPage";
+import {
+  fetchOrganizationSummaries,
+  followOrganization,
+  unfollowOrganization,
+} from "../src/api/organizations";
+import { supabase } from "../src/supabaseClient";
+
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock("../src/api/organizations", () => ({
+  fetchOrganizationSummaries: vi.fn(),
+  followOrganization: vi.fn(),
+  unfollowOrganization: vi.fn(),
+}));
+
+vi.mock("../src/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+beforeEach(() => {
+  navigate.mockReset();
+  fetchOrganizationSummaries.mockReset();
+  followOrganization.mockReset();
+  unfollowOrganization.mockReset();
+  supabase.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: "student-1" } } },
+  });
+});
+
+describe("OrganizationsPage", () => {
+  it("renders organization cards with activity metrics and follow state", async () => {
+    fetchOrganizationSummaries.mockResolvedValue([
+      {
+        id: "organization-1",
+        profile_id: "org-profile-1",
+        username: "acm",
+        name: "ACM",
+        description: "Computer science events",
+        logo_url: null,
+        followers_count: 12,
+        posts_count: 3,
+        likes_count: 18,
+        comments_count: 5,
+        is_following: true,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <OrganizationsPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Loading organizations/i)).toBeInTheDocument();
+
+    expect(await screen.findByText("ACM")).toBeInTheDocument();
+    expect(screen.getByText("@acm")).toBeInTheDocument();
+    expect(screen.getByText("Computer science events")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("18")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getAllByText("Following").length).toBeGreaterThan(0);
+  });
+
+  it("follows an organization without opening the details page", async () => {
+    fetchOrganizationSummaries.mockResolvedValue([
+      {
+        id: "organization-2",
+        profile_id: "org-profile-2",
+        username: "robotics",
+        name: "Robotics Club",
+        description: "Build nights",
+        logo_url: null,
+        followers_count: 4,
+        posts_count: 1,
+        likes_count: 2,
+        comments_count: 0,
+        is_following: false,
+      },
+    ]);
+    followOrganization.mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <OrganizationsPage />
+      </MemoryRouter>
+    );
+
+    const followButton = await screen.findByRole("button", { name: "Follow" });
+    fireEvent.click(followButton);
+
+    await waitFor(() =>
+      expect(followOrganization).toHaveBeenCalledWith(
+        "student-1",
+        "organization-2"
+      )
+    );
+    expect(navigate).not.toHaveBeenCalledWith("/organizations/organization-2");
+    expect(await screen.findAllByText("Following")).toHaveLength(1);
+  });
+
+  it("unfollows an organization from the following button", async () => {
+    fetchOrganizationSummaries.mockResolvedValue([
+      {
+        id: "organization-4",
+        profile_id: "org-profile-4",
+        username: "film",
+        name: "Film Club",
+        description: "Screenings and reviews",
+        logo_url: null,
+        followers_count: 9,
+        posts_count: 2,
+        likes_count: 11,
+        comments_count: 4,
+        is_following: true,
+      },
+    ]);
+    unfollowOrganization.mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <OrganizationsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Following" }));
+
+    await waitFor(() =>
+      expect(unfollowOrganization).toHaveBeenCalledWith(
+        "student-1",
+        "organization-4"
+      )
+    );
+    expect(navigate).not.toHaveBeenCalledWith("/organizations/organization-4");
+    expect(await screen.findByRole("button", { name: "Follow" })).toBeInTheDocument();
+  });
+
+  it("opens organization detail when a card is clicked", async () => {
+    fetchOrganizationSummaries.mockResolvedValue([
+      {
+        id: "organization-3",
+        profile_id: "org-profile-3",
+        username: "dance",
+        name: "Dance Society",
+        description: "Movement workshops",
+        logo_url: null,
+        followers_count: 7,
+        posts_count: 2,
+        likes_count: 8,
+        comments_count: 1,
+        is_following: false,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <OrganizationsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Dance Society/i }));
+
+    expect(navigate).toHaveBeenCalledWith("/organizations/organization-3");
+  });
+});

--- a/client/tests/organizations-page.test.jsx
+++ b/client/tests/organizations-page.test.jsx
@@ -153,6 +153,71 @@ describe("OrganizationsPage", () => {
     expect(await screen.findByRole("button", { name: "Follow" })).toBeInTheDocument();
   });
 
+  it("sorts organizations by relevance, featured activity, and likes", async () => {
+    fetchOrganizationSummaries.mockResolvedValue([
+      {
+        id: "organization-relevant",
+        profile_id: "org-profile-relevant",
+        username: "honors",
+        name: "Honors Board",
+        description: "Student leadership",
+        logo_url: null,
+        followers_count: 4,
+        posts_count: 1,
+        likes_count: 3,
+        comments_count: 1,
+        is_following: true,
+      },
+      {
+        id: "organization-featured",
+        profile_id: "org-profile-featured",
+        username: "service",
+        name: "Service Coalition",
+        description: "Volunteer events",
+        logo_url: null,
+        followers_count: 40,
+        posts_count: 8,
+        likes_count: 12,
+        comments_count: 9,
+        is_following: false,
+      },
+      {
+        id: "organization-liked",
+        profile_id: "org-profile-liked",
+        username: "music",
+        name: "Music Guild",
+        description: "Concert nights",
+        logo_url: null,
+        followers_count: 5,
+        posts_count: 2,
+        likes_count: 80,
+        comments_count: 2,
+        is_following: false,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <OrganizationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Honors Board");
+    expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent(
+      "Honors Board"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Most Featured" }));
+    expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent(
+      "Service Coalition"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Most Liked" }));
+    expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent(
+      "Music Guild"
+    );
+  });
+
   it("opens organization detail when a card is clicked", async () => {
     fetchOrganizationSummaries.mockResolvedValue([
       {

--- a/client/tests/organizations.test.js
+++ b/client/tests/organizations.test.js
@@ -4,6 +4,7 @@ import {
   fetchIsFollowing,
   fetchOrganizationById,
   fetchOrganizationByProfileId,
+  fetchOrganizationSummaries,
   fetchOrganizations,
 } from "../src/api/organizations";
 import { supabase } from "../src/supabaseClient";
@@ -65,6 +66,14 @@ function buildFollowerLookup(response) {
           return Promise.resolve(response);
         },
       };
+    },
+  };
+}
+
+function buildSimpleSelect(response) {
+  return {
+    select() {
+      return Promise.resolve(response);
     },
   };
 }
@@ -196,5 +205,113 @@ describe("Organization followers", () => {
     const follows = await fetchIsFollowing(null, "org-1");
     expect(follows).toBe(false);
     expect(supabase.from).not.toHaveBeenCalled();
+  });
+});
+
+describe("Organization listing API", () => {
+  it("loads organization summaries with the current user id", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url) => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        organizations: [
+          {
+            id: "organization-1",
+            name: "ACM",
+            followers_count: 2,
+            posts_count: 1,
+            likes_count: 4,
+            comments_count: 3,
+            is_following: true,
+          },
+        ],
+      }),
+      statusText: "OK",
+    }));
+
+    try {
+      const results = await fetchOrganizationSummaries("student-1");
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "http://localhost:5000/api/organizations?user_id=student-1",
+        expect.objectContaining({
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+      expect(results[0]).toMatchObject({
+        id: "organization-1",
+        followers_count: 2,
+        is_following: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls back to Supabase summaries when the backend is unavailable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    supabase.from.mockImplementation((table) => {
+      if (table === "organizations") {
+        return buildSimpleSelect({
+          data: [
+            {
+              id: "organization-1",
+              profile_id: "org-profile-1",
+              username: "acm",
+              name: "ACM",
+              description: "CS chapter",
+              logo_url: null,
+            },
+          ],
+          error: null,
+        });
+      }
+
+      if (table === "organization_followers") {
+        return buildSimpleSelect({
+          data: [
+            { user_id: "student-1", organization_id: "organization-1" },
+            { user_id: "student-2", organization_id: "organization-1" },
+          ],
+          error: null,
+        });
+      }
+
+      if (table === "posts") {
+        return buildSimpleSelect({
+          data: [
+            {
+              id: "post-1",
+              user_id: "org-profile-1",
+              likes: 5,
+              comments: [{ text: "Nice" }],
+            },
+          ],
+          error: null,
+        });
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    try {
+      const results = await fetchOrganizationSummaries("student-1");
+
+      expect(results[0]).toMatchObject({
+        id: "organization-1",
+        followers_count: 2,
+        posts_count: 1,
+        likes_count: 5,
+        comments_count: 1,
+        is_following: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -9,6 +9,9 @@ const {
   rewriteDescriptionWithGeminiFallback,
   validateRewriteDescriptionPayload,
 } = require('../utils/aiRewrite');
+const {
+  buildOrganizationSummaries,
+} = require('../utils/organizationMetrics');
 
 // Test GET route
 router.get('/test', (req, res) => {
@@ -34,6 +37,45 @@ router.get('/supabase/health', async (req, res) => {
     }
 
     return res.json({ ok: true, rows: data.length });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/organizations', async (req, res) => {
+  try {
+    const currentUserId =
+      typeof req.query.user_id === 'string' && req.query.user_id.trim()
+        ? req.query.user_id.trim()
+        : null;
+
+    const [organizationsResult, followersResult, postsResult] = await Promise.all([
+      supabase
+        .from('organizations')
+        .select('id, profile_id, username, name, description, logo_url, created_at'),
+      supabase
+        .from('organization_followers')
+        .select('user_id, organization_id'),
+      supabase
+        .from('posts')
+        .select('id, user_id, likes, comments'),
+    ]);
+
+    const firstError =
+      organizationsResult.error || followersResult.error || postsResult.error;
+
+    if (firstError) {
+      return res.status(500).json({ ok: false, error: firstError.message });
+    }
+
+    const organizations = buildOrganizationSummaries({
+      organizations: organizationsResult.data || [],
+      followers: followersResult.data || [],
+      posts: postsResult.data || [],
+      currentUserId,
+    });
+
+    return res.json({ ok: true, organizations });
   } catch (err) {
     return res.status(500).json({ ok: false, error: err.message });
   }

--- a/server/tests/api.integration.test.js
+++ b/server/tests/api.integration.test.js
@@ -12,7 +12,44 @@ function clearModule(modulePath) {
 
 function createInMemorySupabase() {
   const state = {
-    posts: [],
+    organizations: [
+      {
+        id: 'organization-1',
+        profile_id: 'org-profile-1',
+        username: 'acm',
+        name: 'ACM',
+        description: 'Computer science events',
+        logo_url: 'https://example.com/acm.png',
+        created_at: '2026-04-01T12:00:00.000Z',
+      },
+      {
+        id: 'organization-2',
+        profile_id: 'org-profile-2',
+        username: 'robotics',
+        name: 'Robotics Club',
+        description: 'Build nights',
+        logo_url: null,
+        created_at: '2026-04-02T12:00:00.000Z',
+      },
+    ],
+    organization_followers: [
+      { user_id: 'student-1', organization_id: 'organization-1' },
+      { user_id: 'student-2', organization_id: 'organization-1' },
+    ],
+    posts: [
+      {
+        id: 'seed-post-1',
+        user_id: 'org-profile-1',
+        content: 'Welcome',
+        title: 'Welcome',
+        description: 'Welcome to ACM',
+        image_url: null,
+        likes: 6,
+        liked_by: [],
+        comments: [{ id: 'comment-1', text: 'Nice' }, { id: 'comment-2', text: 'See you' }],
+        created_at: '2026-04-03T12:00:00.000Z',
+      },
+    ],
   };
 
   function selectColumns(record, selection) {
@@ -41,6 +78,18 @@ function createInMemorySupabase() {
                 return Promise.resolve({ data: [{ id: 'profile-1' }], error: null });
               },
             };
+          },
+        };
+      }
+
+      if (table === 'organizations' || table === 'organization_followers') {
+        return {
+          select(selection) {
+            const rows = state[table].map((record) =>
+              selectColumns(record, selection)
+            );
+
+            return Promise.resolve({ data: rows, error: null });
           },
         };
       }
@@ -85,6 +134,14 @@ function createInMemorySupabase() {
             return Promise.resolve({ data: rows, error: null });
           }
           return this;
+        },
+        then(resolve, reject) {
+          if (context.action === 'select' && !context.filter) {
+            const rows = state.posts.map((post) => selectColumns(post, context.selection));
+            return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+          }
+
+          return Promise.resolve({ data: null, error: null }).then(resolve, reject);
         },
         single() {
           if (context.action === 'insert') {
@@ -238,6 +295,23 @@ async function run() {
     assert.equal(rewriteBody.ok, true);
     assert.equal(typeof rewriteBody.description, 'string');
     assert.ok(rewriteBody.description.length > 0);
+
+    const organizationsResponse = await fetch(
+      `${server.baseUrl}/api/organizations?user_id=student-1`
+    );
+    const organizationsBody = await organizationsResponse.json();
+    const acm = organizationsBody.organizations.find(
+      (organization) => organization.id === 'organization-1'
+    );
+
+    assert.equal(organizationsResponse.status, 200);
+    assert.equal(organizationsBody.ok, true);
+    assert.equal(organizationsBody.organizations.length, 2);
+    assert.equal(acm.followers_count, 2);
+    assert.equal(acm.posts_count, 1);
+    assert.equal(acm.likes_count, 6);
+    assert.equal(acm.comments_count, 2);
+    assert.equal(acm.is_following, true);
 
     console.log('PASS API integration test');
   } catch (error) {

--- a/server/utils/organizationMetrics.js
+++ b/server/utils/organizationMetrics.js
@@ -1,0 +1,73 @@
+function normalizeCount(value) {
+  const count = Number(value ?? 0);
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}
+
+function normalizeComments(comments) {
+  return Array.isArray(comments) ? comments.length : 0;
+}
+
+function buildOrganizationSummary({
+  organization,
+  followers = [],
+  posts = [],
+  currentUserId = null,
+}) {
+  const organizationPosts = posts.filter(
+    (post) => post.user_id === organization.profile_id
+  );
+  const organizationFollowers = followers.filter(
+    (follower) => follower.organization_id === organization.id
+  );
+
+  return {
+    id: organization.id,
+    profile_id: organization.profile_id,
+    username: organization.username,
+    name: organization.name,
+    description: organization.description ?? null,
+    logo_url: organization.logo_url ?? null,
+    created_at: organization.created_at ?? null,
+    followers_count: organizationFollowers.length,
+    posts_count: organizationPosts.length,
+    likes_count: organizationPosts.reduce(
+      (total, post) => total + normalizeCount(post.likes),
+      0
+    ),
+    comments_count: organizationPosts.reduce(
+      (total, post) => total + normalizeComments(post.comments),
+      0
+    ),
+    is_following: Boolean(
+      currentUserId &&
+        organizationFollowers.some((follower) => follower.user_id === currentUserId)
+    ),
+  };
+}
+
+function buildOrganizationSummaries({
+  organizations = [],
+  followers = [],
+  posts = [],
+  currentUserId = null,
+}) {
+  return organizations
+    .map((organization) =>
+      buildOrganizationSummary({
+        organization,
+        followers,
+        posts,
+        currentUserId,
+      })
+    )
+    .sort((left, right) => {
+      const leftName = (left.name || left.username || '').toLowerCase();
+      const rightName = (right.name || right.username || '').toLowerCase();
+      return leftName.localeCompare(rightName);
+    });
+}
+
+module.exports = {
+  buildOrganizationSummaries,
+  buildOrganizationSummary,
+};


### PR DESCRIPTION
PR Title
Add Organizations listing page with metrics, follow functionality, and filters

Description
This PR replaces the "Clubs" sidebar item with "Organizations" and introduces a new organizations listing page. Users can view organizations in a card layout, follow/unfollow directly, and filter organizations by relevance, likes, or featured status.

Key Changes
Renamed sidebar item from Clubs → Organizations
Added protected route: /organizations
Implemented organizations listing page with card UI
Displayed metrics: followers, posts, likes, comments
Added follow/unfollow functionality from listing page
Added filters:
Most Relevant
Most Liked
Most Featured
Integrated backend API for organization data, metrics, and filtering

Testing
Added frontend tests for organizations page and filters
Added backend integration tests for organizations API

Notes
Clicking a card navigates to /organizations/:orgId
Includes loading, empty, and error states