### PR TITLE
added the event date to create post page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -105,6 +105,10 @@ function mapPostFromApi(post) {
       (typeof post.image_url === "string" && post.image_url.trim()) ||
       parsedLegacy.image ||
       null,
+    eventDate:
+      (typeof post.eventDate === "string" && post.eventDate) ||
+      (typeof post.event_date === "string" && post.event_date) ||
+      null,
     likes: Number(post.likes ?? 0),
     liked_by: Array.isArray(post.liked_by) ? post.liked_by : [],
     comments: Array.isArray(post.comments)
@@ -183,6 +187,7 @@ function App() {
   const [posts, setPosts] = useState([]);
   const [isComposerOpen, setIsComposerOpen] = useState(false);
   const [postTitle, setPostTitle] = useState("");
+  const [postEventDate, setPostEventDate] = useState("");
   const [postDescription, setPostDescription] = useState("");
   const [descriptionTone, setDescriptionTone] = useState("professional");
   const [isRewritingDescription, setIsRewritingDescription] = useState(false);
@@ -327,6 +332,10 @@ function App() {
 
         try {
           const selectAttempts = [
+            "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)",
+            "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)",
+            "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments",
+            "id, user_id, content, title, description, image_url, event_date, created_at, likes",
             "id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)",
             "id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)",
             "id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments",
@@ -389,6 +398,7 @@ function App() {
       URL.revokeObjectURL(postImagePreview);
     }
     setPostTitle("");
+    setPostEventDate("");
     setPostDescription("");
     setDescriptionTone("professional");
     setPostImageFile(null);
@@ -498,6 +508,7 @@ function App() {
     title,
     description,
     imageUrl,
+    eventDate,
   }) => {
     const isMissingColumnError = (error) => {
       const message = String(error?.message || "").toLowerCase();
@@ -505,6 +516,8 @@ function App() {
     };
 
     const selectAttempts = [
+      "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments",
+      "id, user_id, content, title, description, image_url, event_date, created_at, likes",
       "id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments",
       "id, user_id, content, title, description, image_url, created_at, likes",
       "id, user_id, content, created_at, likes, liked_by, comments",
@@ -520,9 +533,19 @@ function App() {
         title,
         description,
         image_url: imageUrl || null,
+        event_date: eventDate || null,
         likes: 0,
         liked_by: [],
         comments: [],
+      },
+      {
+        user_id: userId,
+        content: description,
+        title,
+        description,
+        image_url: imageUrl || null,
+        event_date: eventDate || null,
+        likes: 0,
       },
       {
         user_id: userId,
@@ -725,8 +748,9 @@ function App() {
   const handleCreatePost = async (event) => {
     event.preventDefault();
     const title = postTitle.trim();
+    const eventDate = postEventDate.trim();
     const description = postDescription.trim();
-    const validationError = validateComposerInput({ title, description });
+    const validationError = validateComposerInput({ title, description, eventDate });
 
     if (validationError) {
       setApiError(validationError);
@@ -760,6 +784,7 @@ function App() {
         title,
         description,
         image_url: uploadedImageUrl,
+        eventDate: eventDate || null,
         user_id: session.user.id,
       });
       const savedPost = response?.post ?? response;
@@ -777,6 +802,7 @@ function App() {
             title: savedPost.title ?? title,
             description: savedPost.description ?? description,
             image_url: savedPost.image_url ?? uploadedImageUrl,
+            event_date: (savedPost.event_date ?? savedPost.eventDate ?? eventDate) || null,
             content: savedPost.content ?? description,
             organization_name: savedPost.organization_name ?? organizationName,
             created_at: savedPost.created_at ?? new Date().toISOString(),
@@ -794,6 +820,7 @@ function App() {
           title,
           description,
           imageUrl: uploadedImageUrl,
+          eventDate,
         });
 
         const organizationName =
@@ -808,6 +835,7 @@ function App() {
             title: savedPost.title ?? title,
             description: savedPost.description ?? description,
             image_url: savedPost.image_url ?? uploadedImageUrl,
+            event_date: (savedPost.event_date ?? savedPost.eventDate ?? eventDate) || null,
             content: savedPost.content ?? description,
             organization_name: savedPost.organization_name ?? organizationName,
             created_at: savedPost.created_at ?? new Date().toISOString(),
@@ -1246,6 +1274,23 @@ function App() {
                 <p className="text-xs text-slate-500">
                   {titleLength}/{TITLE_MAX_LENGTH}
                 </p>
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="post-event-date" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Event Date
+                </label>
+                <input
+                  id="post-event-date"
+                  type="date"
+                  value={postEventDate}
+                  onChange={(event) => {
+                    setPostEventDate(event.target.value);
+                    setApiError(null);
+                    setSuccessMessage("");
+                  }}
+                  className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-200"
+                />
               </div>
 
               <div className="space-y-1">

--- a/client/src/lib/postComposerUtils.js
+++ b/client/src/lib/postComposerUtils.js
@@ -28,7 +28,17 @@ export function isNetworkFetchError(error) {
   );
 }
 
-export function validateComposerInput({ title, description }) {
+export function isValidEventDate(value) {
+  if (!value) return true;
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+export function validateComposerInput({ title, description, eventDate }) {
   const normalizedTitle = typeof title === "string" ? title.trim() : "";
   const normalizedDescription =
     typeof description === "string" ? description.trim() : "";
@@ -43,6 +53,10 @@ export function validateComposerInput({ title, description }) {
 
   if (normalizedDescription.length > DESCRIPTION_MAX_LENGTH) {
     return `Description must be ${DESCRIPTION_MAX_LENGTH} characters or fewer.`;
+  }
+
+  if (!isValidEventDate(eventDate)) {
+    return "Event Date must be a valid date.";
   }
 
   return null;

--- a/client/src/lib/postUtils.js
+++ b/client/src/lib/postUtils.js
@@ -19,6 +19,7 @@ export function normalizePost(post) {
     title: post.title ?? "",
     content: post.content ?? post.description ?? "",
     image: post.image ?? post.image_url ?? null,
+    eventDate: post.eventDate ?? post.event_date ?? null,
     likes: Number(post.likes ?? 0),
     liked_by: Array.isArray(post.liked_by) ? post.liked_by : [],
     comments: Array.isArray(post.comments)

--- a/client/tests/post-composer-utils.test.js
+++ b/client/tests/post-composer-utils.test.js
@@ -28,8 +28,22 @@ describe("post composer utils", () => {
 
   it("accepts valid payload", () => {
     expect(
-      validateComposerInput({ title: "Valid title", description: "Valid body" })
+      validateComposerInput({
+        title: "Valid title",
+        description: "Valid body",
+        eventDate: "2026-05-15",
+      })
     ).toBeNull();
+  });
+
+  it("rejects invalid event dates", () => {
+    expect(
+      validateComposerInput({
+        title: "Valid title",
+        description: "Valid body",
+        eventDate: "2026-02-31",
+      })
+    ).toMatch(/event date/i);
   });
 
   it("validates image format and file size", () => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -124,6 +124,8 @@ function normalizePost(post) {
           ? post.content
           : '',
     image_url: typeof post.image_url === 'string' ? post.image_url : null,
+    eventDate: typeof post.event_date === 'string' ? post.event_date : null,
+    event_date: typeof post.event_date === 'string' ? post.event_date : null,
     avatar_url: typeof profile?.avatar_url === 'string' ? profile.avatar_url : null,
     role: typeof profile?.role === 'string' ? profile.role : null,
     content: typeof post.content === 'string' ? post.content : '',
@@ -148,12 +150,16 @@ async function selectPostsWithFallback({ id = null, limit = null } = {}) {
   const selectAttempts = [
     {
       selection:
-        'id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)',
+        'id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)',
       sortBy: 'created_at',
     },
     {
       selection:
-        'id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)',
+        'id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)',
+      sortBy: 'created_at',
+    },
+    {
+      selection: 'id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments',
       sortBy: 'created_at',
     },
     {
@@ -222,13 +228,14 @@ async function selectPostsWithFallback({ id = null, limit = null } = {}) {
   return { error: lastError || new Error('Unable to query posts table.') };
 }
 
-function buildInsertPayload({ userId, content, title, description, imageUrl }) {
+function buildInsertPayload({ userId, content, title, description, imageUrl, eventDate }) {
   const payload = {
     user_id: userId,
     content,
     title,
     description,
     image_url: imageUrl,
+    event_date: eventDate,
     likes: 0,
     liked_by: [],
     comments: [],
@@ -244,6 +251,7 @@ function compactInsertPayload(payload, level) {
 
   if (level >= 1) {
     delete next.comments;
+    delete next.event_date;
   }
 
   if (level >= 2) {
@@ -262,6 +270,10 @@ function compactInsertPayload(payload, level) {
 
 async function insertPostWithFallback(payload) {
   const selectAttempts = [
+    'id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)',
+    'id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)',
+    'id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments',
+    'id, user_id, content, title, description, image_url, event_date, created_at, likes',
     'id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)',
     'id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)',
     'id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments',
@@ -328,12 +340,15 @@ router.post('/posts', async (req, res) => {
       title,
       description,
       image_url,
+      eventDate,
+      event_date,
     } = req.body || {};
     const payloadValidation = validateCreatePostPayload({
       title,
       description,
       content,
       imageUrl: image_url,
+      eventDate: eventDate ?? event_date,
     });
     if (payloadValidation.error) {
       return res.status(400).json({ ok: false, error: payloadValidation.error });
@@ -347,6 +362,7 @@ router.post('/posts', async (req, res) => {
       title: payloadValidation.normalizedTitle,
       description: payloadValidation.normalizedDescription,
       imageUrl: payloadValidation.normalizedImageUrl,
+      eventDate: payloadValidation.normalizedEventDate,
     });
 
     const { data, error } = await insertPostWithFallback(insertBody);
@@ -452,7 +468,7 @@ router.patch('/posts/:id', async (req, res) => {
       .from('posts')
       .update(updates)
       .eq('id', id)
-      .select('id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)')
+      .select('id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)')
       .single();
 
     if (error && schemaCompatibilityError(error)) {

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { supabase } = require('../supabaseClient');
 const { emitNewPost } = require('../sockets/postHandler');
+const { normalizeEventDate } = require('../utils/postValidation');
 
 function authorFromProfile(profile) {
   if (!profile || typeof profile !== 'object') return 'Member';
@@ -50,7 +51,7 @@ function parseFeedPagination(query = {}) {
 
 function mapRow(row) {
   const profile = row.profiles;
-  return {
+  const mapped = {
     id: row.id,
     userId: row.user_id,
     author: authorFromProfile(profile),
@@ -65,6 +66,13 @@ function mapRow(row) {
         ? row.created_at
         : new Date(row.created_at).toISOString()
   };
+
+  if (typeof row.event_date === 'string' && row.event_date) {
+    mapped.eventDate = row.event_date;
+    mapped.event_date = row.event_date;
+  }
+
+  return mapped;
 }
 
 function sortFeedReverseChronological(items) {
@@ -89,7 +97,7 @@ function createPostsRouter(io) {
       const { data, error } = await supabase
         .from('posts')
         .select(
-          'id, content, created_at, user_id, likes, comments, profiles(email, username, full_name, avatar_url, role, organization_description)'
+          'id, content, event_date, created_at, user_id, likes, comments, profiles(email, username, full_name, avatar_url, role, organization_description)'
         )
         .order('created_at', { ascending: false })
         .order('id', { ascending: false })
@@ -115,7 +123,7 @@ function createPostsRouter(io) {
   });
 
   router.post('/', async (req, res) => {
-    const { content, user_id: bodyUserId } = req.body || {};
+    const { content, user_id: bodyUserId, eventDate, event_date } = req.body || {};
 
     if (!content || typeof content !== 'string' || !content.trim()) {
       return res.status(400).json({
@@ -137,16 +145,29 @@ function createPostsRouter(io) {
     }
 
     const postContent = content.trim();
+    const eventDateValidation = normalizeEventDate(eventDate ?? event_date);
+
+    if (eventDateValidation.error) {
+      return res.status(400).json({
+        message: eventDateValidation.error
+      });
+    }
 
     try {
+      const insertPayload = {
+        user_id: userId,
+        content: postContent
+      };
+
+      if (eventDateValidation.eventDate) {
+        insertPayload.event_date = eventDateValidation.eventDate;
+      }
+
       const { data, error } = await supabase
         .from('posts')
-        .insert({
-          user_id: userId,
-          content: postContent
-        })
+        .insert(insertPayload)
         .select(
-          'id, content, created_at, user_id, likes, comments, profiles(email, username, full_name, avatar_url, role, organization_description)'
+          'id, content, event_date, created_at, user_id, likes, comments, profiles(email, username, full_name, avatar_url, role, organization_description)'
         )
         .single();
 

--- a/server/tests/api.posts.test.js
+++ b/server/tests/api.posts.test.js
@@ -110,6 +110,97 @@ test('POST /api/posts rejects invalid image_url', async () => {
   }
 });
 
+test('POST /api/posts stores and returns eventDate', async () => {
+  let insertedPayload = null;
+  const supabase = {
+    from(table) {
+      assert.equal(table, 'posts');
+      return {
+        insert(payload) {
+          insertedPayload = payload;
+          return this;
+        },
+        select() {
+          return this;
+        },
+        single() {
+          return Promise.resolve({
+            data: {
+              id: 'post-with-date',
+              user_id: 'user-1',
+              title: 'Valid title',
+              description: 'Valid description',
+              content: 'Valid description',
+              image_url: null,
+              event_date: '2026-05-15',
+              created_at: '2026-05-01T12:00:00.000Z',
+              likes: 0,
+              liked_by: [],
+              comments: [],
+              profiles: null,
+            },
+            error: null,
+          });
+        },
+      };
+    },
+  };
+
+  const router = loadApiRouter({ supabase });
+  const server = await startTestServer(router);
+
+  try {
+    const response = await fetch(`${server.baseUrl}/api/posts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        user_id: 'user-1',
+        title: 'Valid title',
+        description: 'Valid description',
+        eventDate: '2026-05-15',
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(insertedPayload[0].event_date, '2026-05-15');
+    assert.equal(body.post.eventDate, '2026-05-15');
+    assert.equal(body.post.event_date, '2026-05-15');
+  } finally {
+    await server.close();
+  }
+});
+
+test('POST /api/posts rejects invalid eventDate', async () => {
+  const supabase = {
+    from() {
+      throw new Error('supabase insert should not execute for invalid payload');
+    },
+  };
+
+  const router = loadApiRouter({ supabase });
+  const server = await startTestServer(router);
+
+  try {
+    const response = await fetch(`${server.baseUrl}/api/posts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        user_id: 'user-1',
+        title: 'Valid title',
+        description: 'Valid description',
+        eventDate: '2026-02-31',
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.match(body.error, /eventDate/i);
+  } finally {
+    await server.close();
+  }
+});
+
 test('PATCH /api/posts/:id rejects invalid image_url', async () => {
   const supabase = {
     from() {

--- a/server/utils/postValidation.js
+++ b/server/utils/postValidation.js
@@ -15,7 +15,32 @@ function isValidImageUrl(value) {
   }
 }
 
-function validateCreatePostPayload({ title, description, content, imageUrl }) {
+function normalizeEventDate(value) {
+  if (value == null || value === '') return { error: null, eventDate: null };
+  if (typeof value !== 'string') {
+    return { error: 'eventDate must be a valid date in YYYY-MM-DD format.' };
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return { error: null, eventDate: null };
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return { error: 'eventDate must be a valid date in YYYY-MM-DD format.' };
+  }
+
+  const parsed = new Date(`${trimmed}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return { error: 'eventDate must be a valid date in YYYY-MM-DD format.' };
+  }
+
+  const isoDate = parsed.toISOString().slice(0, 10);
+  if (isoDate !== trimmed) {
+    return { error: 'eventDate must be a valid date in YYYY-MM-DD format.' };
+  }
+
+  return { error: null, eventDate: trimmed };
+}
+
+function validateCreatePostPayload({ title, description, content, imageUrl, eventDate }) {
   const normalizedTitle = typeof title === 'string' ? title.trim() : '';
   const normalizedDescription =
     typeof description === 'string' && description.trim()
@@ -40,12 +65,18 @@ function validateCreatePostPayload({ title, description, content, imageUrl }) {
     return { error: 'image_url must be a valid HTTP(S) URL.' };
   }
 
+  const eventDateValidation = normalizeEventDate(eventDate);
+  if (eventDateValidation.error) {
+    return { error: eventDateValidation.error };
+  }
+
   return {
     error: null,
     normalizedTitle,
     normalizedDescription,
     normalizedImageUrl:
       typeof imageUrl === 'string' && imageUrl.trim() ? imageUrl.trim() : null,
+    normalizedEventDate: eventDateValidation.eventDate,
   };
 }
 
@@ -53,6 +84,7 @@ module.exports = {
   DESCRIPTION_MAX_LENGTH,
   TITLE_MAX_LENGTH,
   isValidImageUrl,
+  normalizeEventDate,
   validateCreatePostPayload,
 };
 

--- a/supabase/migrations/20260504123000_add_event_date_to_posts.sql
+++ b/supabase/migrations/20260504123000_add_event_date_to_posts.sql
@@ -1,0 +1,5 @@
+alter table if exists public.posts
+  add column if not exists event_date date;
+
+create index if not exists posts_event_date_idx
+  on public.posts (event_date);


### PR DESCRIPTION
PR Title
Add Event Date field to Create Post page

Description
This PR introduces a new Event Date field to the Create Post modal, allowing users to specify a date for their campus events. The selected date is included in the post submission and stored on the backend.

Key Changes
Added Event Date input field using a date picker in the Create Post modal
Updated frontend state and API payload to include eventDate
Extended backend API to accept and validate eventDate
Stored event date in the database for each post
Behavior
Event date is optional
Valid date selection enforced via date picker
Event date persists and is returned with post data

Testing
Verified post creation with and without event date
Ensured no regression in existing post functionality

Notes
Field is positioned for logical flow within the form
Future-ready for filtering or displaying event-based posts