### PR TITLE
Scrum 24 cb 406 events tab with internal calendar integration

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,6 +21,7 @@ import {
   DESCRIPTION_TONE_OPTIONS,
   MAX_IMAGE_SIZE_BYTES,
   TITLE_MAX_LENGTH,
+  getTodayDateString,
   isNetworkFetchError,
   isSchemaCompatibilityError,
   isValidImageFile,
@@ -1058,6 +1059,7 @@ function App() {
 
   const titleLength = postTitle.length;
   const descriptionLength = postDescription.length;
+  const todayDate = getTodayDateString();
   const isComposerSubmitDisabled =
     loadingCreate ||
     !postTitle.trim() ||
@@ -1314,6 +1316,7 @@ function App() {
                   id="post-event-date"
                   type="date"
                   value={postEventDate}
+                  min={todayDate}
                   onChange={(event) => {
                     setPostEventDate(event.target.value);
                     setApiError(null);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,18 @@ import {
 
 const POST_CONTENT_PREFIX = "CB_POST_V1::";
 
+function buildPostContentPayload({ title, description, image, eventDate }) {
+  if (!eventDate) return description;
+
+  return `${POST_CONTENT_PREFIX}${encodeURIComponent(
+    JSON.stringify({
+      title,
+      description,
+      image: image || null,
+      eventDate,
+    })
+  )}`;
+}
 
 function newClientUuid() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -53,9 +65,10 @@ function parsePostContent(content) {
       title: typeof parsed.title === "string" ? parsed.title : "",
       description: typeof parsed.description === "string" ? parsed.description : "",
       image: typeof parsed.image === "string" ? parsed.image : null,
+      eventDate: typeof parsed.eventDate === "string" ? parsed.eventDate : null,
     };
   } catch {
-    return { title: "", description: content, image: null };
+    return { title: "", description: content, image: null, eventDate: null };
   }
 }
 
@@ -108,6 +121,7 @@ function mapPostFromApi(post) {
     eventDate:
       (typeof post.eventDate === "string" && post.eventDate) ||
       (typeof post.event_date === "string" && post.event_date) ||
+      parsedLegacy.eventDate ||
       null,
     likes: Number(post.likes ?? 0),
     liked_by: Array.isArray(post.liked_by) ? post.liked_by : [],
@@ -509,6 +523,7 @@ function App() {
     description,
     imageUrl,
     eventDate,
+    content,
   }) => {
     const isMissingColumnError = (error) => {
       const message = String(error?.message || "").toLowerCase();
@@ -526,10 +541,11 @@ function App() {
       "id, user_id, content, created_at",
     ];
 
+    const persistedContent = content || description;
     const payloads = [
       {
         user_id: userId,
-        content: description,
+        content: persistedContent,
         title,
         description,
         image_url: imageUrl || null,
@@ -540,7 +556,7 @@ function App() {
       },
       {
         user_id: userId,
-        content: description,
+        content: persistedContent,
         title,
         description,
         image_url: imageUrl || null,
@@ -549,7 +565,7 @@ function App() {
       },
       {
         user_id: userId,
-        content: description,
+        content: persistedContent,
         title,
         description,
         image_url: imageUrl || null,
@@ -557,7 +573,7 @@ function App() {
       },
       {
         user_id: userId,
-        content: description,
+        content: persistedContent,
       },
     ];
 
@@ -575,7 +591,7 @@ function App() {
           return data;
         }
 
-        if (isMissingColumnError(error)) {
+        if (isMissingColumnError(error) || isSchemaCompatibilityError(error)) {
           lastError = error;
           continue;
         }
@@ -778,9 +794,16 @@ function App() {
       return;
     }
 
+    const contentPayload = buildPostContentPayload({
+      title,
+      description,
+      image: uploadedImageUrl,
+      eventDate,
+    });
+
     try {
       const response = await createPost({
-        content: description,
+        content: contentPayload,
         title,
         description,
         image_url: uploadedImageUrl,
@@ -803,7 +826,7 @@ function App() {
             description: savedPost.description ?? description,
             image_url: savedPost.image_url ?? uploadedImageUrl,
             event_date: (savedPost.event_date ?? savedPost.eventDate ?? eventDate) || null,
-            content: savedPost.content ?? description,
+            content: savedPost.content ?? contentPayload,
             organization_name: savedPost.organization_name ?? organizationName,
             created_at: savedPost.created_at ?? new Date().toISOString(),
           }),
@@ -821,6 +844,7 @@ function App() {
           description,
           imageUrl: uploadedImageUrl,
           eventDate,
+          content: contentPayload,
         });
 
         const organizationName =
@@ -836,7 +860,7 @@ function App() {
             description: savedPost.description ?? description,
             image_url: savedPost.image_url ?? uploadedImageUrl,
             event_date: (savedPost.event_date ?? savedPost.eventDate ?? eventDate) || null,
-            content: savedPost.content ?? description,
+            content: savedPost.content ?? contentPayload,
             organization_name: savedPost.organization_name ?? organizationName,
             created_at: savedPost.created_at ?? new Date().toISOString(),
           }),
@@ -1145,12 +1169,18 @@ function App() {
                 >
                   Organizations
                 </button>
-                <div className="rounded bg-slate-100 p-2 text-left text-slate-700">
+                <button
+                  onClick={() => navigate("/events")}
+                  className="w-full rounded bg-slate-100 p-2 text-left hover:bg-slate-200"
+                >
                   Events
-                </div>
-                <div className="rounded bg-slate-100 p-2 text-left text-slate-700">
+                </button>
+                <button
+                  onClick={() => navigate("/calendar")}
+                  className="w-full rounded bg-slate-100 p-2 text-left hover:bg-slate-200"
+                >
                   Calendar
-                </div>
+                </button>
               </div>
             </div>
           </aside>

--- a/client/src/api/calendar.js
+++ b/client/src/api/calendar.js
@@ -1,0 +1,54 @@
+const CALENDAR_STORAGE_PREFIX = "campusbytes:calendar:";
+
+function storageKey(userId) {
+  return `${CALENDAR_STORAGE_PREFIX}${userId || "guest"}`;
+}
+
+function readEvents(userId) {
+  if (typeof localStorage === "undefined") return [];
+
+  try {
+    const parsed = JSON.parse(localStorage.getItem(storageKey(userId)) || "[]");
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeEvents(userId, events) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(storageKey(userId), JSON.stringify(events));
+}
+
+export async function fetchCalendarEvents(userId) {
+  return readEvents(userId).sort((a, b) =>
+    String(a.eventDate || "").localeCompare(String(b.eventDate || ""))
+  );
+}
+
+export async function saveCalendarEvent(userId, event) {
+  const normalized = {
+    postId: event.postId ?? event.id,
+    title: event.title || "Untitled event",
+    eventDate: event.eventDate,
+    image: event.image || null,
+  };
+
+  if (!normalized.postId || !normalized.eventDate) {
+    throw new Error("Calendar event requires a post and event date.");
+  }
+
+  const events = readEvents(userId);
+  const existingIndex = events.findIndex(
+    (entry) => String(entry.postId) === String(normalized.postId)
+  );
+
+  if (existingIndex >= 0) {
+    events[existingIndex] = { ...events[existingIndex], ...normalized };
+  } else {
+    events.push(normalized);
+  }
+
+  writeEvents(userId, events);
+  return normalized;
+}

--- a/client/src/api/calendar.js
+++ b/client/src/api/calendar.js
@@ -1,3 +1,5 @@
+import { isPastEventDate } from "../lib/postComposerUtils";
+
 const CALENDAR_STORAGE_PREFIX = "campusbytes:calendar:";
 
 function storageKey(userId) {
@@ -21,7 +23,14 @@ function writeEvents(userId, events) {
 }
 
 export async function fetchCalendarEvents(userId) {
-  return readEvents(userId).sort((a, b) =>
+  const events = readEvents(userId);
+  const upcomingEvents = events.filter((event) => !isPastEventDate(event.eventDate));
+
+  if (upcomingEvents.length !== events.length) {
+    writeEvents(userId, upcomingEvents);
+  }
+
+  return upcomingEvents.sort((a, b) =>
     String(a.eventDate || "").localeCompare(String(b.eventDate || ""))
   );
 }
@@ -36,6 +45,10 @@ export async function saveCalendarEvent(userId, event) {
 
   if (!normalized.postId || !normalized.eventDate) {
     throw new Error("Calendar event requires a post and event date.");
+  }
+
+  if (isPastEventDate(normalized.eventDate)) {
+    throw new Error("Expired events cannot be added to Calendar.");
   }
 
   const events = readEvents(userId);

--- a/client/src/api/calendar.js
+++ b/client/src/api/calendar.js
@@ -50,5 +50,24 @@ export async function saveCalendarEvent(userId, event) {
   }
 
   writeEvents(userId, events);
-  return normalized;
+  return {
+    event: normalized,
+    alreadyAdded: existingIndex >= 0,
+  };
+}
+
+export async function removeCalendarEvent(userId, postId) {
+  if (!postId) {
+    throw new Error("Calendar event requires a post.");
+  }
+
+  const events = readEvents(userId);
+  const nextEvents = events.filter(
+    (entry) => String(entry.postId) !== String(postId)
+  );
+
+  writeEvents(userId, nextEvents);
+  return {
+    removed: nextEvents.length !== events.length,
+  };
 }

--- a/client/src/api/organizations.js
+++ b/client/src/api/organizations.js
@@ -202,7 +202,7 @@ export async function fetchOrganizationPosts(organization) {
   const { data, error } = await supabase
     .from("posts")
     .select(
-      "id, user_id, title, description, image_url, content, created_at, likes, liked_by, comments"
+      "id, user_id, title, description, image_url, content, event_date, created_at, likes, liked_by, comments"
     )
     .eq("user_id", organization.profile_id)
     .order("created_at", { ascending: false });

--- a/client/src/api/posts.js
+++ b/client/src/api/posts.js
@@ -1,0 +1,66 @@
+import { fetchPosts } from "./config";
+import { supabase } from "../supabaseClient";
+import { isSchemaCompatibilityError } from "../lib/postComposerUtils";
+import { normalizePost } from "../lib/postUtils";
+
+async function fetchPostsDirectFromSupabase() {
+  const selectAttempts = [
+    "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)",
+    "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments, profiles(username, email, avatar_url, role)",
+    "id, user_id, content, title, description, image_url, event_date, created_at, likes, liked_by, comments",
+    "id, user_id, content, title, description, image_url, event_date, created_at, likes",
+    "id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments, profiles(full_name, username, email, avatar_url, role)",
+    "id, user_id, content, title, description, image_url, created_at, likes, liked_by, comments",
+    "id, user_id, content, created_at, likes, liked_by, comments",
+    "id, user_id, content, created_at, likes",
+    "id, user_id, content, created_at",
+  ];
+
+  let lastError = null;
+
+  for (const selection of selectAttempts) {
+    const orderColumn = selection.includes("created_at") ? "created_at" : "id";
+    const { data, error } = await supabase
+      .from("posts")
+      .select(selection)
+      .order(orderColumn, { ascending: false })
+      .limit(100);
+
+    if (!error) {
+      return data ?? [];
+    }
+
+    if (isSchemaCompatibilityError(error)) {
+      lastError = error;
+      continue;
+    }
+
+    throw error;
+  }
+
+  throw lastError || new Error("Unable to load posts.");
+}
+
+export async function fetchAllPosts() {
+  let posts;
+
+  try {
+    const payload = await fetchPosts();
+    posts = Array.isArray(payload) ? payload : payload.posts ?? [];
+  } catch (error) {
+    console.warn("Posts API unavailable, falling back to Supabase:", error.message);
+    posts = await fetchPostsDirectFromSupabase();
+  }
+
+  return posts.map(normalizePost);
+}
+
+export async function fetchEventPosts() {
+  const posts = await fetchAllPosts();
+  return posts.filter((post) => Boolean(post.eventDate));
+}
+
+export async function fetchPostById(postId) {
+  const posts = await fetchAllPosts();
+  return posts.find((post) => String(post.id) === String(postId)) ?? null;
+}

--- a/client/src/components/EventCard.jsx
+++ b/client/src/components/EventCard.jsx
@@ -12,7 +12,13 @@ function formatEventDate(eventDate) {
   });
 }
 
-function EventCard({ event, onOpen, onAddToCalendar, actionLabel = "Add to Calendar" }) {
+function EventCard({
+  event,
+  onOpen,
+  onAddToCalendar,
+  actionLabel = "Add to Calendar",
+  isCalendarActionVisible = true,
+}) {
   const handleAddToCalendar = (clickEvent) => {
     clickEvent.stopPropagation();
     onAddToCalendar(event);
@@ -49,15 +55,17 @@ function EventCard({ event, onOpen, onAddToCalendar, actionLabel = "Add to Calen
           </h2>
         </div>
       </button>
-      <div className="mt-auto flex justify-end border-t border-slate-100 p-4 pt-3">
-        <button
-          type="button"
-          onClick={handleAddToCalendar}
-          className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
-        >
-          {actionLabel}
-        </button>
-      </div>
+      {isCalendarActionVisible && (
+        <div className="mt-auto flex justify-end border-t border-slate-100 p-4 pt-3">
+          <button
+            type="button"
+            onClick={handleAddToCalendar}
+            className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+          >
+            {actionLabel}
+          </button>
+        </div>
+      )}
     </article>
   );
 }

--- a/client/src/components/EventCard.jsx
+++ b/client/src/components/EventCard.jsx
@@ -1,0 +1,71 @@
+function formatEventDate(eventDate) {
+  if (!eventDate) return "Date TBD";
+
+  const parsed = new Date(`${eventDate}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return eventDate;
+
+  return parsed.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function EventCard({ event, onOpen, onAddToCalendar, actionLabel = "Add to Calendar" }) {
+  const handleAddToCalendar = (clickEvent) => {
+    clickEvent.stopPropagation();
+    onAddToCalendar(event);
+  };
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(event)}
+      onKeyDown={(keyEvent) => {
+        if (keyEvent.key === "Enter" || keyEvent.key === " ") {
+          keyEvent.preventDefault();
+          onOpen(event);
+        }
+      }}
+      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-200"
+    >
+      <div className="block w-full text-left">
+        <div className="aspect-[16/9] w-full bg-slate-100">
+          {event.image ? (
+            <img
+              src={event.image}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center bg-gradient-to-br from-sky-100 via-white to-emerald-100 text-sm font-semibold text-slate-500">
+              Campus Event
+            </div>
+          )}
+        </div>
+        <div className="space-y-2 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+            {formatEventDate(event.eventDate)}
+          </p>
+          <h2 className="line-clamp-2 text-lg font-semibold text-slate-900">
+            {event.title || "Untitled event"}
+          </h2>
+        </div>
+      </div>
+      <div className="mt-auto flex justify-end border-t border-slate-100 p-4 pt-3">
+        <button
+          type="button"
+          onClick={handleAddToCalendar}
+          className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+        >
+          {actionLabel}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export { formatEventDate };
+export default EventCard;

--- a/client/src/components/EventCard.jsx
+++ b/client/src/components/EventCard.jsx
@@ -20,18 +20,13 @@ function EventCard({ event, onOpen, onAddToCalendar, actionLabel = "Add to Calen
 
   return (
     <article
-      role="button"
-      tabIndex={0}
-      onClick={() => onOpen(event)}
-      onKeyDown={(keyEvent) => {
-        if (keyEvent.key === "Enter" || keyEvent.key === " ") {
-          keyEvent.preventDefault();
-          onOpen(event);
-        }
-      }}
-      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-200"
+      className="flex h-full flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
     >
-      <div className="block w-full text-left">
+      <button
+        type="button"
+        onClick={() => onOpen(event)}
+        className="block w-full flex-1 cursor-pointer text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-200"
+      >
         <div className="aspect-[16/9] w-full bg-slate-100">
           {event.image ? (
             <img
@@ -53,7 +48,7 @@ function EventCard({ event, onOpen, onAddToCalendar, actionLabel = "Add to Calen
             {event.title || "Untitled event"}
           </h2>
         </div>
-      </div>
+      </button>
       <div className="mt-auto flex justify-end border-t border-slate-100 p-4 pt-3">
         <button
           type="button"

--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -68,6 +68,7 @@ function PostCard({ post, onLike, onToggleComments, onAddComment, onOpenProfile 
 
       <div className="flex items-center gap-3 border-t border-slate-100 pt-3">
         <button
+          type="button"
           onClick={() => onLike(post.id)}
           className="flex items-center gap-2 rounded-lg bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-blue-100 hover:text-blue-600"
         >
@@ -75,6 +76,7 @@ function PostCard({ post, onLike, onToggleComments, onAddComment, onOpenProfile 
         </button>
 
         <button
+          type="button"
           onClick={() => onToggleComments(post.id)}
           className="flex items-center gap-2 rounded-lg bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-blue-100 hover:text-blue-600"
         >
@@ -108,13 +110,13 @@ function PostCard({ post, onLike, onToggleComments, onAddComment, onOpenProfile 
             onSubmit={(e) => {
               e.preventDefault();
               const form = e.target;
-              const input = form.comment;
-              const value = input.value.trim();
+              const formData = new FormData(form);
+              const value = String(formData.get("comment") ?? "").trim();
 
               if (!value) return;
 
               onAddComment(post.id, value);
-              input.value = "";
+              form.reset();
             }}
             className="flex gap-2"
           >

--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -1,5 +1,7 @@
 ﻿import AvatarBadge from "./AvatarBadge";
 
+import { formatEventDate } from "./EventCard";
+
 function formatPostDate(createdAt) {
   if (!createdAt) return "Campus update";
 
@@ -46,6 +48,12 @@ function PostCard({ post, onLike, onToggleComments, onAddComment, onOpenProfile 
         <h4 className="mb-2 text-lg font-bold tracking-tight text-slate-900">
           {post.title}
         </h4>
+      )}
+
+      {post.eventDate && (
+        <p className="mb-3 rounded-md bg-sky-50 px-3 py-2 text-sm font-semibold text-sky-800">
+          Event Date: {formatEventDate(post.eventDate)}
+        </p>
       )}
 
       <p className="mb-3 whitespace-pre-wrap text-slate-700">{post.content}</p>

--- a/client/src/lib/postComposerUtils.js
+++ b/client/src/lib/postComposerUtils.js
@@ -38,6 +38,19 @@ export function isValidEventDate(value) {
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
 }
 
+export function getTodayDateString() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+export function isPastEventDate(value) {
+  return isValidEventDate(value) && Boolean(value) && value < getTodayDateString();
+}
+
 export function validateComposerInput({ title, description, eventDate }) {
   const normalizedTitle = typeof title === "string" ? title.trim() : "";
   const normalizedDescription =
@@ -57,6 +70,10 @@ export function validateComposerInput({ title, description, eventDate }) {
 
   if (!isValidEventDate(eventDate)) {
     return "Event Date must be a valid date.";
+  }
+
+  if (isPastEventDate(eventDate)) {
+    return "Event Date cannot be in the past.";
   }
 
   return null;

--- a/client/src/lib/postUtils.js
+++ b/client/src/lib/postUtils.js
@@ -6,7 +6,36 @@ export function newClientUuid() {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
 
+const POST_CONTENT_PREFIX = "CB_POST_V1::";
+
+export function parsePostContent(content) {
+  if (typeof content !== "string") {
+    return { title: "", description: "", image: null, eventDate: null };
+  }
+
+  if (!content.startsWith(POST_CONTENT_PREFIX)) {
+    return { title: "", description: content, image: null, eventDate: null };
+  }
+
+  try {
+    const parsed = JSON.parse(
+      decodeURIComponent(content.slice(POST_CONTENT_PREFIX.length))
+    );
+
+    return {
+      title: typeof parsed.title === "string" ? parsed.title : "",
+      description: typeof parsed.description === "string" ? parsed.description : "",
+      image: typeof parsed.image === "string" ? parsed.image : null,
+      eventDate: typeof parsed.eventDate === "string" ? parsed.eventDate : null,
+    };
+  } catch {
+    return { title: "", description: content, image: null, eventDate: null };
+  }
+}
+
 export function normalizePost(post) {
+  const parsedContent = parsePostContent(post.content);
+
   return {
     id: post.id,
     userId: post.userId ?? post.user_id ?? null,
@@ -16,10 +45,10 @@ export function normalizePost(post) {
     avatarUrl: post.avatarUrl ?? post.avatar_url ?? null,
     role: post.role ?? null,
     description: post.description ?? post.organizationDescription ?? null,
-    title: post.title ?? "",
-    content: post.content ?? post.description ?? "",
-    image: post.image ?? post.image_url ?? null,
-    eventDate: post.eventDate ?? post.event_date ?? null,
+    title: post.title || parsedContent.title || "",
+    content: post.description || parsedContent.description || post.content || "",
+    image: post.image ?? post.image_url ?? parsedContent.image ?? null,
+    eventDate: post.eventDate ?? post.event_date ?? parsedContent.eventDate ?? null,
     likes: Number(post.likes ?? 0),
     liked_by: Array.isArray(post.liked_by) ? post.liked_by : [],
     comments: Array.isArray(post.comments)

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -12,6 +12,9 @@ import App from "./App.jsx";
 import AuthPage from "./pages/AuthPage";
 import OrganizationDetailsPage from "./pages/OrganizationDetailsPage";
 import OrganizationsPage from "./pages/OrganizationsPage";
+import EventsPage from "./pages/EventsPage";
+import CalendarPage from "./pages/CalendarPage";
+import PostDetailsPage from "./pages/PostDetailsPage";
 import { supabase } from "./supabaseClient";
 import UserProfile from "./pages/UserProfile";
 import EditProfile from "./pages/EditProfile";
@@ -87,6 +90,30 @@ createRoot(document.getElementById("root")).render(
           element={
             <RequireAuth>
               <OrganizationDetailsPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/events"
+          element={
+            <RequireAuth>
+              <EventsPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/calendar"
+          element={
+            <RequireAuth>
+              <CalendarPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/posts/:postId"
+          element={
+            <RequireAuth>
+              <PostDetailsPage />
             </RequireAuth>
           }
         />

--- a/client/src/pages/CalendarPage.jsx
+++ b/client/src/pages/CalendarPage.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchCalendarEvents } from "../api/calendar";
+import { formatEventDate } from "../components/EventCard";
+import { supabase } from "../supabaseClient";
+
+function CalendarPage() {
+  const navigate = useNavigate();
+  const [events, setEvents] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadCalendar() {
+      try {
+        setIsLoading(true);
+        const { data } = await supabase.auth.getSession();
+        const savedEvents = await fetchCalendarEvents(data.session?.user?.id ?? null);
+        if (isMounted) {
+          setEvents(savedEvents);
+          setError("");
+        }
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError.message || "Unable to load Calendar.");
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    loadCalendar();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-sky-200 via-blue-100 to-slate-200 px-4 py-8">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => navigate("/")}
+            className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            Back to Dashboard
+          </button>
+
+          <div className="flex flex-wrap gap-2 text-sm text-slate-700">
+            <span className="rounded-full bg-white/85 px-3 py-1 shadow-sm">
+              {events.length} saved events
+            </span>
+          </div>
+        </div>
+
+        <section className="rounded-md border border-white/70 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.14)] backdrop-blur">
+          <div className="mb-6">
+            <h1 className="text-3xl font-semibold text-slate-900">
+              Calendar
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Review the campus events you saved from event posts.
+            </p>
+          </div>
+
+          {error && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <div className="sr-only" aria-live="polite">
+                Loading Calendar...
+              </div>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-md border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="h-24 animate-pulse rounded-md bg-slate-200" />
+                  <div className="mt-4 space-y-3 animate-pulse">
+                    <div className="h-4 w-28 rounded-full bg-slate-100" />
+                    <div className="h-6 w-44 rounded-full bg-slate-200" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : events.length === 0 ? (
+            <div className="rounded-md border border-dashed border-slate-300 bg-white/85 p-8 text-center text-slate-600">
+              No saved events yet.
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {events.map((event) => (
+                <article
+                  key={event.postId}
+                  className="flex h-full flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
+                >
+                  <div className="aspect-[16/9] w-full bg-slate-100">
+                    {event.image ? (
+                      <img
+                        src={event.image}
+                        alt=""
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full items-center justify-center bg-gradient-to-br from-sky-100 via-white to-emerald-100 text-sm font-semibold text-slate-500">
+                        Saved Event
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-1 flex-col p-4">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+                      {formatEventDate(event.eventDate)}
+                    </p>
+                    <h2 className="mt-2 line-clamp-2 text-lg font-semibold text-slate-900">
+                      {event.title}
+                    </h2>
+                    <div className="mt-auto flex justify-end pt-5">
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/posts/${event.postId}`)}
+                        className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-900"
+                      >
+                        View Post
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default CalendarPage;

--- a/client/src/pages/EventsPage.jsx
+++ b/client/src/pages/EventsPage.jsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import EventCard from "../components/EventCard";
-import { saveCalendarEvent } from "../api/calendar";
+import {
+  fetchCalendarEvents,
+  removeCalendarEvent,
+  saveCalendarEvent,
+} from "../api/calendar";
 import { fetchEventPosts } from "../api/posts";
 import { supabase } from "../supabaseClient";
 
@@ -10,6 +14,7 @@ function EventsPage() {
   const [events, setEvents] = useState([]);
   const [sortDirection, setSortDirection] = useState("asc");
   const [sessionUserId, setSessionUserId] = useState(null);
+  const [calendarPostIds, setCalendarPostIds] = useState(new Set());
   const [statusMessage, setStatusMessage] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -24,10 +29,15 @@ function EventsPage() {
           supabase.auth.getSession(),
           fetchEventPosts(),
         ]);
+        const userId = data.session?.user?.id ?? null;
+        const savedEvents = await fetchCalendarEvents(userId);
 
         if (!isMounted) return;
-        setSessionUserId(data.session?.user?.id ?? null);
+        setSessionUserId(userId);
         setEvents(eventPosts);
+        setCalendarPostIds(
+          new Set(savedEvents.map((event) => String(event.postId)))
+        );
         setError("");
       } catch (loadError) {
         if (isMounted) {
@@ -61,18 +71,42 @@ function EventsPage() {
     }).length;
   }, [events]);
 
-  const handleAddToCalendar = async (event) => {
+  const handleToggleCalendar = async (event) => {
+    const eventTitle = event.title || "Event";
+    const isInCalendar = calendarPostIds.has(String(event.id));
+
     try {
-      await saveCalendarEvent(sessionUserId, {
+      if (isInCalendar) {
+        await removeCalendarEvent(sessionUserId, event.id);
+        setStatusMessage(`${eventTitle} removed from Calendar.`);
+        setCalendarPostIds((currentIds) => {
+          const nextIds = new Set(currentIds);
+          nextIds.delete(String(event.id));
+          return nextIds;
+        });
+        setError("");
+        return;
+      }
+
+      const result = await saveCalendarEvent(sessionUserId, {
         postId: event.id,
         title: event.title,
         eventDate: event.eventDate,
         image: event.image,
       });
-      setStatusMessage(`${event.title || "Event"} added to Calendar.`);
+      setStatusMessage(
+        result?.alreadyAdded
+          ? `${eventTitle} is already in your Calendar.`
+          : `${eventTitle} added to Calendar.`
+      );
+      setCalendarPostIds((currentIds) => {
+        const nextIds = new Set(currentIds);
+        nextIds.add(String(event.id));
+        return nextIds;
+      });
       setError("");
-    } catch (saveError) {
-      setError(saveError.message || "Unable to add event to Calendar.");
+    } catch (calendarError) {
+      setError(calendarError.message || "Unable to update Calendar.");
     }
   };
 
@@ -173,8 +207,13 @@ function EventsPage() {
                 <EventCard
                   key={event.id}
                   event={event}
+                  actionLabel={
+                    calendarPostIds.has(String(event.id))
+                      ? "Added to Calendar"
+                      : "Add to Calendar"
+                  }
                   onOpen={() => navigate(`/posts/${event.id}`)}
-                  onAddToCalendar={handleAddToCalendar}
+                  onAddToCalendar={handleToggleCalendar}
                 />
               ))}
             </div>

--- a/client/src/pages/EventsPage.jsx
+++ b/client/src/pages/EventsPage.jsx
@@ -13,7 +13,7 @@ import { supabase } from "../supabaseClient";
 function EventsPage() {
   const navigate = useNavigate();
   const [events, setEvents] = useState([]);
-  const [sortDirection, setSortDirection] = useState("asc");
+  const [eventStatusFilter, setEventStatusFilter] = useState("active");
   const [sessionUserId, setSessionUserId] = useState(null);
   const [calendarPostIds, setCalendarPostIds] = useState(new Set());
   const [statusMessage, setStatusMessage] = useState("");
@@ -55,12 +55,14 @@ function EventsPage() {
     };
   }, []);
 
-  const sortedEvents = useMemo(() => {
-    return [...events].sort((a, b) => {
-      const comparison = String(a.eventDate).localeCompare(String(b.eventDate));
-      return sortDirection === "asc" ? comparison : -comparison;
-    });
-  }, [events, sortDirection]);
+  const visibleEvents = useMemo(() => {
+    return events
+      .filter((event) => {
+        const isExpired = isPastEventDate(event.eventDate);
+        return eventStatusFilter === "expired" ? isExpired : !isExpired;
+      })
+      .sort((a, b) => String(a.eventDate).localeCompare(String(b.eventDate)));
+  }, [events, eventStatusFilter]);
 
   const upcomingCount = useMemo(() => {
     const today = new Date();
@@ -146,16 +148,16 @@ function EventsPage() {
 
           <div className="mb-5 flex flex-wrap items-center gap-2">
             {[
-              { value: "asc", label: "Oldest" },
-              { value: "desc", label: "Latest" },
+              { value: "active", label: "Active" },
+              { value: "expired", label: "Expired" },
             ].map((filter) => {
-              const isActive = sortDirection === filter.value;
+              const isActive = eventStatusFilter === filter.value;
 
               return (
                 <button
                   key={filter.value}
                   type="button"
-                  onClick={() => setSortDirection(filter.value)}
+                  onClick={() => setEventStatusFilter(filter.value)}
                   aria-pressed={isActive}
                   className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
                     isActive
@@ -198,13 +200,13 @@ function EventsPage() {
                 </div>
               ))}
             </div>
-          ) : sortedEvents.length === 0 ? (
+          ) : visibleEvents.length === 0 ? (
             <div className="rounded-md border border-dashed border-slate-300 bg-white/85 p-8 text-center text-slate-600">
-              No dated events have been posted yet.
+              No {eventStatusFilter} events have been posted yet.
             </div>
           ) : (
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {sortedEvents.map((event) => (
+              {visibleEvents.map((event) => (
                 <EventCard
                   key={event.id}
                   event={event}

--- a/client/src/pages/EventsPage.jsx
+++ b/client/src/pages/EventsPage.jsx
@@ -7,6 +7,7 @@ import {
   saveCalendarEvent,
 } from "../api/calendar";
 import { fetchEventPosts } from "../api/posts";
+import { isPastEventDate } from "../lib/postComposerUtils";
 import { supabase } from "../supabaseClient";
 
 function EventsPage() {
@@ -207,6 +208,7 @@ function EventsPage() {
                 <EventCard
                   key={event.id}
                   event={event}
+                  isCalendarActionVisible={!isPastEventDate(event.eventDate)}
                   actionLabel={
                     calendarPostIds.has(String(event.id))
                       ? "Added to Calendar"

--- a/client/src/pages/EventsPage.jsx
+++ b/client/src/pages/EventsPage.jsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import EventCard from "../components/EventCard";
+import { saveCalendarEvent } from "../api/calendar";
+import { fetchEventPosts } from "../api/posts";
+import { supabase } from "../supabaseClient";
+
+function EventsPage() {
+  const navigate = useNavigate();
+  const [events, setEvents] = useState([]);
+  const [sortDirection, setSortDirection] = useState("asc");
+  const [sessionUserId, setSessionUserId] = useState(null);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function load() {
+      try {
+        setIsLoading(true);
+        const [{ data }, eventPosts] = await Promise.all([
+          supabase.auth.getSession(),
+          fetchEventPosts(),
+        ]);
+
+        if (!isMounted) return;
+        setSessionUserId(data.session?.user?.id ?? null);
+        setEvents(eventPosts);
+        setError("");
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError.message || "Unable to load events.");
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const sortedEvents = useMemo(() => {
+    return [...events].sort((a, b) => {
+      const comparison = String(a.eventDate).localeCompare(String(b.eventDate));
+      return sortDirection === "asc" ? comparison : -comparison;
+    });
+  }, [events, sortDirection]);
+
+  const upcomingCount = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    return events.filter((event) => {
+      const parsed = new Date(`${event.eventDate}T00:00:00`);
+      return !Number.isNaN(parsed.getTime()) && parsed >= today;
+    }).length;
+  }, [events]);
+
+  const handleAddToCalendar = async (event) => {
+    try {
+      await saveCalendarEvent(sessionUserId, {
+        postId: event.id,
+        title: event.title,
+        eventDate: event.eventDate,
+        image: event.image,
+      });
+      setStatusMessage(`${event.title || "Event"} added to Calendar.`);
+      setError("");
+    } catch (saveError) {
+      setError(saveError.message || "Unable to add event to Calendar.");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-sky-200 via-blue-100 to-slate-200 px-4 py-8">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => navigate("/")}
+            className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            Back to Dashboard
+          </button>
+
+          <div className="flex flex-wrap gap-2 text-sm text-slate-700">
+            <span className="rounded-full bg-white/85 px-3 py-1 shadow-sm">
+              {events.length} events
+            </span>
+            <span className="rounded-full bg-white/85 px-3 py-1 shadow-sm">
+              {upcomingCount} upcoming
+            </span>
+          </div>
+        </div>
+
+        <section className="rounded-md border border-white/70 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.14)] backdrop-blur">
+          <div className="mb-6">
+            <h1 className="text-3xl font-semibold text-slate-900">
+              Events
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Browse campus posts with event dates and add the ones you want to
+              your Calendar.
+            </p>
+          </div>
+
+          <div className="mb-5 flex flex-wrap items-center gap-2">
+            {[
+              { value: "asc", label: "Oldest" },
+              { value: "desc", label: "Latest" },
+            ].map((filter) => {
+              const isActive = sortDirection === filter.value;
+
+              return (
+                <button
+                  key={filter.value}
+                  type="button"
+                  onClick={() => setSortDirection(filter.value)}
+                  aria-pressed={isActive}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    isActive
+                      ? "bg-slate-900 text-white shadow-sm"
+                      : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {statusMessage && (
+            <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+              {statusMessage}
+            </div>
+          )}
+          {error && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <div className="sr-only" aria-live="polite">
+                Loading events...
+              </div>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-md border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="aspect-[16/9] animate-pulse rounded-md bg-slate-200" />
+                  <div className="mt-4 space-y-3 animate-pulse">
+                    <div className="h-4 w-28 rounded-full bg-slate-100" />
+                    <div className="h-6 w-44 rounded-full bg-slate-200" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : sortedEvents.length === 0 ? (
+            <div className="rounded-md border border-dashed border-slate-300 bg-white/85 p-8 text-center text-slate-600">
+              No dated events have been posted yet.
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {sortedEvents.map((event) => (
+                <EventCard
+                  key={event.id}
+                  event={event}
+                  onOpen={() => navigate(`/posts/${event.id}`)}
+                  onAddToCalendar={handleAddToCalendar}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default EventsPage;

--- a/client/src/pages/PostDetailsPage.jsx
+++ b/client/src/pages/PostDetailsPage.jsx
@@ -2,13 +2,29 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import PostCard from "../components/PostCard";
 import { fetchPostById } from "../api/posts";
+import { updatePost } from "../api/config";
+import { newClientUuid, normalizePost, toggleComments } from "../lib/postUtils";
+import { supabase } from "../supabaseClient";
+
+function mergePersistedPost(previousPost, persistedPost) {
+  const normalized = normalizePost(persistedPost);
+
+  return {
+    ...normalized,
+    organization_name:
+      normalized.organization_name ?? previousPost?.organization_name ?? null,
+    showComments: previousPost?.showComments ?? false,
+  };
+}
 
 function PostDetailsPage() {
   const { postId } = useParams();
   const navigate = useNavigate();
   const [post, setPost] = useState(null);
+  const [session, setSession] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState("");
+  const [actionError, setActionError] = useState("");
 
   useEffect(() => {
     let isMounted = true;
@@ -16,8 +32,12 @@ function PostDetailsPage() {
     async function loadPost() {
       try {
         setIsLoading(true);
-        const foundPost = await fetchPostById(postId);
+        const [{ data }, foundPost] = await Promise.all([
+          supabase.auth.getSession(),
+          fetchPostById(postId),
+        ]);
         if (!isMounted) return;
+        setSession(data.session ?? null);
         setPost(foundPost);
         setError(foundPost ? "" : "Post not found.");
       } catch (loadError) {
@@ -34,6 +54,94 @@ function PostDetailsPage() {
       isMounted = false;
     };
   }, [postId]);
+
+  const handleLike = async (id) => {
+    const userId = session?.user?.id;
+    if (!userId) {
+      setActionError("Please sign in to like posts.");
+      return;
+    }
+
+    const previousPost = post;
+    const likedBy = Array.isArray(post.liked_by) ? post.liked_by : [];
+    const userHasLiked = likedBy.includes(userId);
+    const currentLikes =
+      typeof post.likes === "number" && Number.isFinite(post.likes) && post.likes >= 0
+        ? post.likes
+        : likedBy.length;
+    const nextLikedBy = userHasLiked
+      ? likedBy.filter((entry) => entry !== userId)
+      : [...likedBy, userId];
+    const nextLikes = userHasLiked
+      ? Math.max(currentLikes - 1, 0)
+      : currentLikes + 1;
+
+    setActionError("");
+    setPost({ ...post, liked_by: nextLikedBy, likes: nextLikes });
+
+    try {
+      const saved = await updatePost(id, { like_user_id: userId });
+      if (saved && typeof saved === "object") {
+        setPost((currentPost) =>
+          currentPost ? mergePersistedPost(currentPost, saved) : currentPost
+        );
+      }
+    } catch (likeError) {
+      setPost(previousPost);
+      setActionError(likeError.message || "Unable to update likes right now.");
+    }
+  };
+
+  const handleToggleComments = (id) => {
+    setPost((currentPost) =>
+      currentPost ? toggleComments([currentPost], id)[0] : currentPost
+    );
+  };
+
+  const handleAddComment = async (id, commentText) => {
+    const trimmedComment = commentText.trim();
+    if (!trimmedComment) return;
+
+    const user = session?.user;
+    if (!user?.id) {
+      setActionError("Please sign in to comment on posts.");
+      return;
+    }
+
+    const previousPost = post;
+    const authorName =
+      (typeof user.user_metadata?.full_name === "string" &&
+        user.user_metadata.full_name.trim()) ||
+      (typeof user.user_metadata?.username === "string" &&
+        user.user_metadata.username.trim()) ||
+      (typeof user.email === "string" && user.email.trim()) ||
+      "Anonymous";
+    const optimisticComment = {
+      id: newClientUuid(),
+      text: trimmedComment,
+      user_id: user.id,
+      author_name: authorName,
+    };
+    const updatedPost = {
+      ...post,
+      comments: [...(Array.isArray(post.comments) ? post.comments : []), optimisticComment],
+    };
+
+    setActionError("");
+    setPost(updatedPost);
+
+    try {
+      const saved = await updatePost(id, { comments: updatedPost.comments });
+      if (saved && typeof saved === "object") {
+        setPost((currentPost) =>
+          currentPost ? mergePersistedPost(currentPost, saved) : currentPost
+        );
+      }
+    } catch (commentError) {
+      setPost(previousPost);
+      setActionError(commentError.message || "Unable to add the comment right now.");
+    }
+  };
 
   return (
     <div className="min-h-screen bg-slate-100 px-4 py-6 text-slate-900 sm:px-6">
@@ -58,12 +166,19 @@ function PostDetailsPage() {
             {error}
           </div>
         ) : (
-          <PostCard
-            post={post}
-            onLike={() => {}}
-            onToggleComments={() => {}}
-            onAddComment={() => {}}
-          />
+          <>
+            {actionError && (
+              <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+                {actionError}
+              </div>
+            )}
+            <PostCard
+              post={post}
+              onLike={handleLike}
+              onToggleComments={handleToggleComments}
+              onAddComment={handleAddComment}
+            />
+          </>
         )}
       </div>
     </div>

--- a/client/src/pages/PostDetailsPage.jsx
+++ b/client/src/pages/PostDetailsPage.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import PostCard from "../components/PostCard";
+import { fetchPostById } from "../api/posts";
+
+function PostDetailsPage() {
+  const { postId } = useParams();
+  const navigate = useNavigate();
+  const [post, setPost] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadPost() {
+      try {
+        setIsLoading(true);
+        const foundPost = await fetchPostById(postId);
+        if (!isMounted) return;
+        setPost(foundPost);
+        setError(foundPost ? "" : "Post not found.");
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError.message || "Unable to load post.");
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    loadPost();
+    return () => {
+      isMounted = false;
+    };
+  }, [postId]);
+
+  return (
+    <div className="min-h-screen bg-slate-100 px-4 py-6 text-slate-900 sm:px-6">
+      <div className="mx-auto flex max-w-3xl flex-col gap-5">
+        <header className="rounded-md border border-slate-200 bg-white/80 p-4 shadow-sm">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="mb-2 text-sm font-semibold text-sky-700 hover:text-sky-900"
+          >
+            Back
+          </button>
+          <h1 className="text-2xl font-bold tracking-tight">Post Details</h1>
+        </header>
+
+        {isLoading ? (
+          <div className="rounded-md border border-slate-200 bg-white p-8 text-center text-slate-600">
+            Loading post...
+          </div>
+        ) : error ? (
+          <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        ) : (
+          <PostCard
+            post={post}
+            onLike={() => {}}
+            onToggleComments={() => {}}
+            onAddComment={() => {}}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PostDetailsPage;

--- a/client/tests/calendar-api.test.js
+++ b/client/tests/calendar-api.test.js
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { fetchCalendarEvents, saveCalendarEvent } from "../src/api/calendar";
+import {
+  fetchCalendarEvents,
+  removeCalendarEvent,
+  saveCalendarEvent,
+} from "../src/api/calendar";
 
 describe("calendar api", () => {
   beforeEach(() => {
@@ -7,13 +11,13 @@ describe("calendar api", () => {
   });
 
   it("persists saved calendar events by user and prevents duplicates", async () => {
-    await saveCalendarEvent("student-1", {
+    const firstSave = await saveCalendarEvent("student-1", {
       postId: "post-1",
       title: "Career Fair",
       eventDate: "2026-05-20",
       image: "https://example.com/career.png",
     });
-    await saveCalendarEvent("student-1", {
+    const secondSave = await saveCalendarEvent("student-1", {
       postId: "post-1",
       title: "Career Fair Updated",
       eventDate: "2026-05-20",
@@ -28,5 +32,22 @@ describe("calendar api", () => {
       title: "Career Fair Updated",
       eventDate: "2026-05-20",
     });
+    expect(firstSave.alreadyAdded).toBe(false);
+    expect(secondSave.alreadyAdded).toBe(true);
+  });
+
+  it("removes saved calendar events by post id", async () => {
+    await saveCalendarEvent("student-1", {
+      postId: "post-1",
+      title: "Career Fair",
+      eventDate: "2026-05-20",
+      image: null,
+    });
+
+    const result = await removeCalendarEvent("student-1", "post-1");
+    const events = await fetchCalendarEvents("student-1");
+
+    expect(result.removed).toBe(true);
+    expect(events).toEqual([]);
   });
 });

--- a/client/tests/calendar-api.test.js
+++ b/client/tests/calendar-api.test.js
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { fetchCalendarEvents, saveCalendarEvent } from "../src/api/calendar";
+
+describe("calendar api", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists saved calendar events by user and prevents duplicates", async () => {
+    await saveCalendarEvent("student-1", {
+      postId: "post-1",
+      title: "Career Fair",
+      eventDate: "2026-05-20",
+      image: "https://example.com/career.png",
+    });
+    await saveCalendarEvent("student-1", {
+      postId: "post-1",
+      title: "Career Fair Updated",
+      eventDate: "2026-05-20",
+      image: null,
+    });
+
+    const events = await fetchCalendarEvents("student-1");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      postId: "post-1",
+      title: "Career Fair Updated",
+      eventDate: "2026-05-20",
+    });
+  });
+});

--- a/client/tests/calendar-api.test.js
+++ b/client/tests/calendar-api.test.js
@@ -50,4 +50,47 @@ describe("calendar api", () => {
     expect(result.removed).toBe(true);
     expect(events).toEqual([]);
   });
+
+  it("prunes expired events when calendar events are loaded", async () => {
+    localStorage.setItem(
+      "campusbytes:calendar:student-1",
+      JSON.stringify([
+        {
+          postId: "expired-post",
+          title: "Old Fair",
+          eventDate: "2000-01-01",
+          image: null,
+        },
+        {
+          postId: "upcoming-post",
+          title: "Future Fair",
+          eventDate: "2099-05-20",
+          image: null,
+        },
+      ])
+    );
+
+    const events = await fetchCalendarEvents("student-1");
+    const persistedEvents = JSON.parse(
+      localStorage.getItem("campusbytes:calendar:student-1")
+    );
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        postId: "upcoming-post",
+      }),
+    ]);
+    expect(persistedEvents).toEqual(events);
+  });
+
+  it("rejects saving expired events", async () => {
+    await expect(
+      saveCalendarEvent("student-1", {
+        postId: "expired-post",
+        title: "Old Fair",
+        eventDate: "2000-01-01",
+        image: null,
+      })
+    ).rejects.toThrow(/expired/i);
+  });
 });

--- a/client/tests/calendar-page.test.jsx
+++ b/client/tests/calendar-page.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CalendarPage from "../src/pages/CalendarPage";
+import { fetchCalendarEvents } from "../src/api/calendar";
+import { supabase } from "../src/supabaseClient";
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock("../src/api/calendar", () => ({
+  fetchCalendarEvents: vi.fn(),
+}));
+
+vi.mock("../src/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+beforeEach(() => {
+  fetchCalendarEvents.mockReset();
+  supabase.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: "student-1" } } },
+  });
+});
+
+describe("CalendarPage", () => {
+  it("displays saved calendar events", async () => {
+    fetchCalendarEvents.mockResolvedValue([
+      {
+        postId: "post-1",
+        title: "Career Fair",
+        eventDate: "2026-05-20",
+        image: "https://example.com/career.png",
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <CalendarPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Career Fair")).toBeInTheDocument();
+    expect(fetchCalendarEvents).toHaveBeenCalledWith("student-1");
+    expect(screen.getByRole("button", { name: "View Post" })).toBeInTheDocument();
+  });
+});

--- a/client/tests/events-page.test.jsx
+++ b/client/tests/events-page.test.jsx
@@ -53,7 +53,7 @@ beforeEach(() => {
 });
 
 describe("EventsPage", () => {
-  it("renders event posts, sorts by event date, and opens post details", async () => {
+  it("filters active and expired events in chronological order and opens post details", async () => {
     fetchEventPosts.mockResolvedValue([
       {
         id: "later-post",
@@ -67,6 +67,18 @@ describe("EventsPage", () => {
         eventDate: "2026-05-10",
         image: null,
       },
+      {
+        id: "expired-later-post",
+        title: "Old Game Night",
+        eventDate: "2000-05-20",
+        image: null,
+      },
+      {
+        id: "expired-early-post",
+        title: "Old Service Day",
+        eventDate: "2000-05-10",
+        image: null,
+      },
     ]);
 
     render(
@@ -76,13 +88,17 @@ describe("EventsPage", () => {
     );
 
     expect(await screen.findByText("Morning Meetup")).toBeInTheDocument();
-    const headingsAscending = screen.getAllByRole("heading", { level: 2 });
-    expect(headingsAscending[0]).toHaveTextContent("Morning Meetup");
-    expect(headingsAscending[1]).toHaveTextContent("Late Night Breakfast");
+    expect(screen.queryByText("Old Service Day")).not.toBeInTheDocument();
+    const activeHeadings = screen.getAllByRole("heading", { level: 2 });
+    expect(activeHeadings[0]).toHaveTextContent("Morning Meetup");
+    expect(activeHeadings[1]).toHaveTextContent("Late Night Breakfast");
 
-    fireEvent.click(screen.getByRole("button", { name: "Latest" }));
-    const headingsDescending = screen.getAllByRole("heading", { level: 2 });
-    expect(headingsDescending[0]).toHaveTextContent("Late Night Breakfast");
+    fireEvent.click(screen.getByRole("button", { name: "Expired" }));
+    const expiredHeadings = screen.getAllByRole("heading", { level: 2 });
+    expect(expiredHeadings[0]).toHaveTextContent("Old Service Day");
+    expect(expiredHeadings[1]).toHaveTextContent("Old Game Night");
+
+    fireEvent.click(screen.getByRole("button", { name: "Active" }));
 
     fireEvent.click(screen.getByRole("button", { name: /late night breakfast/i }));
     expect(navigate).toHaveBeenCalledWith("/posts/later-post");
@@ -236,6 +252,7 @@ describe("EventsPage", () => {
       </MemoryRouter>
     );
 
+    fireEvent.click(await screen.findByRole("button", { name: "Expired" }));
     expect(await screen.findByText("Old Service Day")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /calendar/i })

--- a/client/tests/events-page.test.jsx
+++ b/client/tests/events-page.test.jsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import EventsPage from "../src/pages/EventsPage";
+import { fetchEventPosts } from "../src/api/posts";
+import { saveCalendarEvent } from "../src/api/calendar";
+import { supabase } from "../src/supabaseClient";
+
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock("../src/api/posts", () => ({
+  fetchEventPosts: vi.fn(),
+}));
+
+vi.mock("../src/api/calendar", () => ({
+  saveCalendarEvent: vi.fn(),
+}));
+
+vi.mock("../src/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+beforeEach(() => {
+  navigate.mockReset();
+  fetchEventPosts.mockReset();
+  saveCalendarEvent.mockReset();
+  supabase.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: "student-1" } } },
+  });
+});
+
+describe("EventsPage", () => {
+  it("renders event posts, sorts by event date, and opens post details", async () => {
+    fetchEventPosts.mockResolvedValue([
+      {
+        id: "later-post",
+        title: "Late Night Breakfast",
+        eventDate: "2026-05-20",
+        image: "https://example.com/late.jpg",
+      },
+      {
+        id: "early-post",
+        title: "Morning Meetup",
+        eventDate: "2026-05-10",
+        image: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <EventsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Morning Meetup")).toBeInTheDocument();
+    const headingsAscending = screen.getAllByRole("heading", { level: 2 });
+    expect(headingsAscending[0]).toHaveTextContent("Morning Meetup");
+    expect(headingsAscending[1]).toHaveTextContent("Late Night Breakfast");
+
+    fireEvent.click(screen.getByRole("button", { name: "Latest" }));
+    const headingsDescending = screen.getAllByRole("heading", { level: 2 });
+    expect(headingsDescending[0]).toHaveTextContent("Late Night Breakfast");
+
+    fireEvent.click(screen.getByRole("button", { name: /late night breakfast/i }));
+    expect(navigate).toHaveBeenCalledWith("/posts/later-post");
+  });
+
+  it("adds an event to calendar for the current user", async () => {
+    fetchEventPosts.mockResolvedValue([
+      {
+        id: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      },
+    ]);
+    saveCalendarEvent.mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <EventsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add to Calendar" }));
+
+    await waitFor(() =>
+      expect(saveCalendarEvent).toHaveBeenCalledWith("student-1", {
+        postId: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      })
+    );
+    expect(screen.getByText(/Service Day added to Calendar/i)).toBeInTheDocument();
+  });
+});

--- a/client/tests/events-page.test.jsx
+++ b/client/tests/events-page.test.jsx
@@ -219,4 +219,26 @@ describe("EventsPage", () => {
       screen.getByRole("button", { name: "Add to Calendar" })
     ).toBeInTheDocument();
   });
+
+  it("does not show the calendar action for past events", async () => {
+    fetchEventPosts.mockResolvedValue([
+      {
+        id: "past-event",
+        title: "Old Service Day",
+        eventDate: "2000-01-01",
+        image: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <EventsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Old Service Day")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /calendar/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/client/tests/events-page.test.jsx
+++ b/client/tests/events-page.test.jsx
@@ -105,6 +105,7 @@ describe("EventsPage", () => {
         image: null,
       })
     );
+    expect(navigate).not.toHaveBeenCalled();
     expect(screen.getByText(/Service Day added to Calendar/i)).toBeInTheDocument();
   });
 });

--- a/client/tests/events-page.test.jsx
+++ b/client/tests/events-page.test.jsx
@@ -4,7 +4,11 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EventsPage from "../src/pages/EventsPage";
 import { fetchEventPosts } from "../src/api/posts";
-import { saveCalendarEvent } from "../src/api/calendar";
+import {
+  fetchCalendarEvents,
+  removeCalendarEvent,
+  saveCalendarEvent,
+} from "../src/api/calendar";
 import { supabase } from "../src/supabaseClient";
 
 const navigate = vi.fn();
@@ -22,6 +26,8 @@ vi.mock("../src/api/posts", () => ({
 }));
 
 vi.mock("../src/api/calendar", () => ({
+  fetchCalendarEvents: vi.fn(),
+  removeCalendarEvent: vi.fn(),
   saveCalendarEvent: vi.fn(),
 }));
 
@@ -36,10 +42,14 @@ vi.mock("../src/supabaseClient", () => ({
 beforeEach(() => {
   navigate.mockReset();
   fetchEventPosts.mockReset();
+  fetchCalendarEvents.mockReset();
+  removeCalendarEvent.mockReset();
   saveCalendarEvent.mockReset();
   supabase.auth.getSession.mockResolvedValue({
     data: { session: { user: { id: "student-1" } } },
   });
+  fetchCalendarEvents.mockResolvedValue([]);
+  removeCalendarEvent.mockResolvedValue({ removed: true });
 });
 
 describe("EventsPage", () => {
@@ -87,7 +97,7 @@ describe("EventsPage", () => {
         image: null,
       },
     ]);
-    saveCalendarEvent.mockResolvedValue(undefined);
+    saveCalendarEvent.mockResolvedValue({ alreadyAdded: false });
 
     render(
       <MemoryRouter>
@@ -107,5 +117,106 @@ describe("EventsPage", () => {
     );
     expect(navigate).not.toHaveBeenCalled();
     expect(screen.getByText(/Service Day added to Calendar/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Added to Calendar" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows when an event is already on the calendar", async () => {
+    fetchEventPosts.mockResolvedValue([
+      {
+        id: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      },
+    ]);
+    saveCalendarEvent.mockResolvedValue({ alreadyAdded: true });
+
+    render(
+      <MemoryRouter>
+        <EventsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add to Calendar" }));
+
+    expect(
+      await screen.findByText(/Service Day is already in your Calendar/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Added to Calendar" })
+    ).toBeInTheDocument();
+  });
+
+  it("labels events that were already saved to the calendar", async () => {
+    fetchEventPosts.mockResolvedValue([
+      {
+        id: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      },
+    ]);
+    fetchCalendarEvents.mockResolvedValue([
+      {
+        postId: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <EventsPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Added to Calendar" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add to Calendar" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes an already saved event from the calendar when clicked again", async () => {
+    fetchEventPosts.mockResolvedValue([
+      {
+        id: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      },
+    ]);
+    fetchCalendarEvents.mockResolvedValue([
+      {
+        postId: "event-post",
+        title: "Service Day",
+        eventDate: "2026-05-12",
+        image: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <EventsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Added to Calendar" })
+    );
+
+    await waitFor(() =>
+      expect(removeCalendarEvent).toHaveBeenCalledWith("student-1", "event-post")
+    );
+    expect(
+      screen.getByText(/Service Day removed from Calendar/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to Calendar" })
+    ).toBeInTheDocument();
   });
 });

--- a/client/tests/organizations.test.js
+++ b/client/tests/organizations.test.js
@@ -4,6 +4,7 @@ import {
   fetchIsFollowing,
   fetchOrganizationById,
   fetchOrganizationByProfileId,
+  fetchOrganizationPosts,
   fetchOrganizationSummaries,
   fetchOrganizations,
 } from "../src/api/organizations";
@@ -313,5 +314,48 @@ describe("Organization listing API", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe("Organization posts", () => {
+  it("loads event dates for organization detail posts", async () => {
+    const selections = [];
+    supabase.from.mockImplementation((table) => {
+      expect(table).toBe("posts");
+      return buildOrganizationsSelect(
+        {
+          data: [
+            {
+              id: "post-1",
+              user_id: "profile-1",
+              title: "Spring Tournament",
+              description: "Registration opens this week.",
+              image_url: null,
+              content: "Registration opens this week.",
+              event_date: "2026-05-12",
+              created_at: "2026-04-28T09:00:00.000Z",
+              likes: 9,
+              liked_by: [],
+              comments: [],
+            },
+          ],
+          error: null,
+        },
+        (entry) => selections.push(entry)
+      );
+    });
+
+    const posts = await fetchOrganizationPosts({
+      id: "org-1",
+      profile_id: "profile-1",
+      name: "Chess Club",
+      logo_url: null,
+    });
+
+    expect(selections[0]).toContain("event_date");
+    expect(posts[0]).toMatchObject({
+      id: "post-1",
+      eventDate: "2026-05-12",
+    });
   });
 });

--- a/client/tests/post-composer-utils.test.js
+++ b/client/tests/post-composer-utils.test.js
@@ -31,7 +31,7 @@ describe("post composer utils", () => {
       validateComposerInput({
         title: "Valid title",
         description: "Valid body",
-        eventDate: "2026-05-15",
+        eventDate: "2099-05-15",
       })
     ).toBeNull();
   });
@@ -44,6 +44,16 @@ describe("post composer utils", () => {
         eventDate: "2026-02-31",
       })
     ).toMatch(/event date/i);
+  });
+
+  it("rejects past event dates", () => {
+    expect(
+      validateComposerInput({
+        title: "Valid title",
+        description: "Valid body",
+        eventDate: "2000-01-01",
+      })
+    ).toMatch(/past/i);
   });
 
   it("validates image format and file size", () => {

--- a/client/tests/post-details-page.test.jsx
+++ b/client/tests/post-details-page.test.jsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PostDetailsPage from "../src/pages/PostDetailsPage";
+import { updatePost } from "../src/api/config";
+import { fetchPostById } from "../src/api/posts";
+import { supabase } from "../src/supabaseClient";
+
+vi.mock("../src/api/posts", () => ({
+  fetchPostById: vi.fn(),
+}));
+
+vi.mock("../src/api/config", () => ({
+  updatePost: vi.fn(),
+}));
+
+vi.mock("../src/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+function buildPost(overrides = {}) {
+  return {
+    id: "post-1",
+    userId: "org-1",
+    organization_name: "Campus Robotics",
+    avatarUrl: null,
+    title: "Open Lab",
+    content: "Stop by for demos.",
+    likes: 3,
+    liked_by: [],
+    comments: [],
+    createdAt: "2026-04-21T12:00:00.000Z",
+    showComments: false,
+    ...overrides,
+  };
+}
+
+function renderDetails() {
+  return render(
+    <MemoryRouter initialEntries={["/posts/post-1"]}>
+      <Routes>
+        <Route path="/posts/:postId" element={<PostDetailsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  fetchPostById.mockReset();
+  updatePost.mockReset();
+  supabase.auth.getSession.mockResolvedValue({
+    data: {
+      session: {
+        user: {
+          id: "student-1",
+          email: "student@example.edu",
+          user_metadata: { full_name: "Student One" },
+        },
+      },
+    },
+  });
+});
+
+describe("PostDetailsPage", () => {
+  it("persists likes from the details page controls", async () => {
+    const post = buildPost();
+    fetchPostById.mockResolvedValue(post);
+    updatePost.mockResolvedValue({
+      ...post,
+      likes: 4,
+      liked_by: ["student-1"],
+    });
+
+    renderDetails();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Like (3)" }));
+
+    expect(screen.getByRole("button", { name: "Like (4)" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(updatePost).toHaveBeenCalledWith("post-1", {
+        like_user_id: "student-1",
+      })
+    );
+  });
+
+  it("persists comments from the details page controls", async () => {
+    const post = buildPost({ showComments: true });
+    fetchPostById.mockResolvedValue(post);
+    updatePost.mockImplementation((_postId, updates) =>
+      Promise.resolve({
+        ...post,
+        comments: updates.comments,
+      })
+    );
+
+    renderDetails();
+
+    fireEvent.change(await screen.findByPlaceholderText("Write a comment..."), {
+      target: { value: "Looking forward to it" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(screen.getByText("Looking forward to it")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(updatePost).toHaveBeenCalledWith(
+        "post-1",
+        expect.objectContaining({
+          comments: [
+            expect.objectContaining({
+              text: "Looking forward to it",
+              user_id: "student-1",
+              author_name: "Student One",
+            }),
+          ],
+        })
+      )
+    );
+  });
+});

--- a/client/tests/posts-api.test.js
+++ b/client/tests/posts-api.test.js
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchEventPosts } from "../src/api/posts";
+import { fetchPosts } from "../src/api/config";
+import { supabase } from "../src/supabaseClient";
+
+vi.mock("../src/api/config", () => ({
+  fetchPosts: vi.fn(),
+}));
+
+vi.mock("../src/supabaseClient", () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  fetchPosts.mockReset();
+  supabase.from.mockReset();
+});
+
+describe("posts api", () => {
+  it("returns only posts with event dates", async () => {
+    const embeddedContent = `CB_POST_V1::${encodeURIComponent(
+      JSON.stringify({
+        title: "Embedded Event",
+        description: "Details",
+        eventDate: "2026-05-22",
+      })
+    )}`;
+    fetchPosts.mockResolvedValue([
+      {
+        id: "event-post",
+        title: "Event",
+        content: "Details",
+        eventDate: "2026-05-20",
+      },
+      {
+        id: "embedded-event-post",
+        content: embeddedContent,
+      },
+      {
+        id: "regular-post",
+        title: "Regular",
+        content: "Update",
+      },
+    ]);
+
+    const events = await fetchEventPosts();
+
+    expect(events).toHaveLength(2);
+    expect(events[0].id).toBe("event-post");
+    expect(events[0].eventDate).toBe("2026-05-20");
+    expect(events[1].id).toBe("embedded-event-post");
+    expect(events[1].eventDate).toBe("2026-05-22");
+  });
+
+  it("falls back to Supabase when the posts API is unavailable", async () => {
+    fetchPosts.mockRejectedValue(new Error("Failed to fetch"));
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "supabase-event",
+            title: "Supabase Event",
+            content: "Details",
+            event_date: "2026-05-21",
+          },
+        ],
+        error: null,
+      }),
+    });
+
+    const events = await fetchEventPosts();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe("supabase-event");
+    expect(events[0].eventDate).toBe("2026-05-21");
+  });
+});

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -13,6 +13,8 @@ const {
   buildOrganizationSummaries,
 } = require('../utils/organizationMetrics');
 
+const POST_CONTENT_PREFIX = 'CB_POST_V1::';
+
 // Test GET route
 router.get('/test', (req, res) => {
   res.json({ message: 'GET route working!' });
@@ -358,7 +360,10 @@ router.post('/posts', async (req, res) => {
 
     const insertBody = buildInsertPayload({
       userId: resolvedUserId,
-      content: payloadValidation.normalizedDescription,
+      content:
+        typeof content === 'string' && content.startsWith(POST_CONTENT_PREFIX)
+          ? content
+          : payloadValidation.normalizedDescription,
       title: payloadValidation.normalizedTitle,
       description: payloadValidation.normalizedDescription,
       imageUrl: payloadValidation.normalizedImageUrl,

--- a/server/tests/api.posts.test.js
+++ b/server/tests/api.posts.test.js
@@ -132,7 +132,7 @@ test('POST /api/posts stores and returns eventDate', async () => {
               description: 'Valid description',
               content: 'Valid description',
               image_url: null,
-              event_date: '2026-05-15',
+              event_date: '2099-05-15',
               created_at: '2026-05-01T12:00:00.000Z',
               likes: 0,
               liked_by: [],
@@ -157,15 +157,15 @@ test('POST /api/posts stores and returns eventDate', async () => {
         user_id: 'user-1',
         title: 'Valid title',
         description: 'Valid description',
-        eventDate: '2026-05-15',
+        eventDate: '2099-05-15',
       }),
     });
     const body = await response.json();
 
     assert.equal(response.status, 201);
-    assert.equal(insertedPayload[0].event_date, '2026-05-15');
-    assert.equal(body.post.eventDate, '2026-05-15');
-    assert.equal(body.post.event_date, '2026-05-15');
+    assert.equal(insertedPayload[0].event_date, '2099-05-15');
+    assert.equal(body.post.eventDate, '2099-05-15');
+    assert.equal(body.post.event_date, '2099-05-15');
   } finally {
     await server.close();
   }
@@ -196,6 +196,36 @@ test('POST /api/posts rejects invalid eventDate', async () => {
 
     assert.equal(response.status, 400);
     assert.match(body.error, /eventDate/i);
+  } finally {
+    await server.close();
+  }
+});
+
+test('POST /api/posts rejects past eventDate', async () => {
+  const supabase = {
+    from() {
+      throw new Error('supabase insert should not execute for past eventDate');
+    },
+  };
+
+  const router = loadApiRouter({ supabase });
+  const server = await startTestServer(router);
+
+  try {
+    const response = await fetch(`${server.baseUrl}/api/posts`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        user_id: 'user-1',
+        title: 'Valid title',
+        description: 'Valid description',
+        eventDate: '2000-01-01',
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.match(body.error, /past/i);
   } finally {
     await server.close();
   }

--- a/server/utils/postValidation.js
+++ b/server/utils/postValidation.js
@@ -37,6 +37,17 @@ function normalizeEventDate(value) {
     return { error: 'eventDate must be a valid date in YYYY-MM-DD format.' };
   }
 
+  const today = new Date();
+  const todayDate = [
+    today.getFullYear(),
+    String(today.getMonth() + 1).padStart(2, '0'),
+    String(today.getDate()).padStart(2, '0'),
+  ].join('-');
+
+  if (trimmed < todayDate) {
+    return { error: 'eventDate cannot be in the past.' };
+  }
+
   return { error: null, eventDate: trimmed };
 }
 


### PR DESCRIPTION
PR Title
Add Events tab with internal calendar integration and filtering

Description
This PR introduces an Events tab in the student dashboard that displays posts with event dates in a card-based layout. Users can view event details, filter events by date, and add events to an internal Calendar tab.

Key Changes
Added Events page to display event-based posts (title, date, image only)
Implemented Add to Calendar functionality (internal dashboard calendar)
Added Calendar tab to view saved events
Implemented filtering (ascending/descending by event date)
Enabled navigation from event card to post details page

Testing
Verified event listing, filtering, and navigation
Tested adding events to internal calendar and persistence

Notes
Event cards do not display descriptions
Only posts with eventDate are shown in Events tab